### PR TITLE
ensure we append -stdlib=libc++ on os x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,16 @@
 #
 #------------------------------------------------------------------------------
 
-CXX=g++ --std=c++11
+# first inherit from env
+CXX := $(CXX)
+CXXFLAGS := $(CXXFLAGS) -std=c++11
+LDFLAGS := $(LDFLAGS)
+
+OS:=$(shell uname -s)
+ifeq ($(OS),Darwin)
+	CXXFLAGS += -stdlib=libc++
+	LDFLAGS += -stdlib=libc++
+endif
 
 INCLUDE_FILES := $(shell find include -name \*.hpp | sort)
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -19,6 +19,13 @@ CXXFLAGS += -O3
 CXXFLAGS += -std=c++11 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
 CXXFLAGS += -I../include -I/usr/include/libshp
 
+OS:=$(shell uname -s)
+ifeq ($(OS),Darwin)
+  # atomic_bool workaround is a libc++ bug in current lib: http://stackoverflow.com/questions/14136128/clang-doesnt-know-stdatomic-bool-but-xcode-does
+	CXXFLAGS += -stdlib=libc++ -D"atomic_bool=atomic<bool>"
+	LDFLAGS += -stdlib=libc++
+endif
+
 # remove this if you do not want debugging to be compiled in
 CXXFLAGS += -DOSMIUM_WITH_DEBUG
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -22,6 +22,10 @@ if [ -z "$CXXFLAGS" ]; then
     CXXFLAGS="-g -std=c++11"
 fi
 
+if [ `uname -s` = 'Darwin' ]; then
+    CXXFLAGS="${CXXFLAGS} -stdlib=libc++"
+fi
+
 COMPILE="$CXX -I../include -I. $CXXFLAGS $CXXFLAGS_WARNINGS -o tests"
 
 if [ "x$1" = "x-v" ]; then


### PR DESCRIPTION
`-stdlib=libc++` is needed on OS X to link to `libc++` instead of `libstdc++`, the former with supports c++11 and the later which does not (since apple is not updating it). More info at: http://libcxx.llvm.org/.

This includes Makefile fixes to append the right flags + one workaround for a missing typedef that is only fixed in unreleased libc++.
