### PR TITLE
Fix OS X tests compile

### DIFF
--- a/include/osmium/detail/typed_mmap.hpp
+++ b/include/osmium/detail/typed_mmap.hpp
@@ -41,6 +41,11 @@ DEALINGS IN THE SOFTWARE.
 #include <sys/types.h>
 #include <unistd.h>
 
+// for bsd systems
+#ifndef MAP_ANONYMOUS
+# define MAP_ANONYMOUS MAP_ANON
+#endif
+
 namespace osmium {
 
     /**

--- a/include/osmium/index/map/mmap_vector_anon.hpp
+++ b/include/osmium/index/map/mmap_vector_anon.hpp
@@ -33,6 +33,8 @@ DEALINGS IN THE SOFTWARE.
 
 */
 
+#ifdef __linux__
+
 #include <osmium/index/map/vector.hpp>
 #include <osmium/detail/mmap_vector_anon.hpp>
 
@@ -53,5 +55,7 @@ namespace osmium {
     } // namespace index
 
 } // namespace osmium
+
+#endif // __linux__
 
 #endif // OSMIUM_INDEX_MAP_MMAP_VECTOR_ANON_HPP

--- a/include/osmium/index/multimap/mmap_vector_anon.hpp
+++ b/include/osmium/index/multimap/mmap_vector_anon.hpp
@@ -33,6 +33,8 @@ DEALINGS IN THE SOFTWARE.
 
 */
 
+#ifdef __linux__
+
 #include <osmium/index/multimap/vector.hpp>
 #include <osmium/detail/mmap_vector_anon.hpp>
 
@@ -50,5 +52,7 @@ namespace osmium {
     } // namespace index
 
 } // namespace osmium
+
+#endif // __linux__
 
 #endif // OSMIUM_INDEX_MULTIMAP_MMAP_VECTOR_ANON_HPP

--- a/test/t/index/test_id_to_location.cpp
+++ b/test/t/index/test_id_to_location.cpp
@@ -91,6 +91,7 @@ BOOST_AUTO_TEST_CASE(DenseMapMem) {
     test_func_real<index_type>(index2);
 }
 
+#ifdef __linux__
 BOOST_AUTO_TEST_CASE(DenseMapMmap) {
     typedef osmium::index::map::DenseMapMmap<osmium::unsigned_object_id_type, osmium::Location> index_type;
 
@@ -100,6 +101,7 @@ BOOST_AUTO_TEST_CASE(DenseMapMmap) {
     index_type index2;
     test_func_real<index_type>(index2);
 }
+#endif
 
 BOOST_AUTO_TEST_CASE(DenseMapFile) {
     typedef osmium::index::map::DenseMapFile<osmium::unsigned_object_id_type, osmium::Location> index_type;


### PR DESCRIPTION
There was a start to a few `#ifdef __linux__` to avoid `remap` problems on OS X, but this pull finishes that work so all the tests compile and pass.
