### PR TITLE
There is a deadlock if reader is closed too early

### DIFF
--- a/include/osmium/io/detail/read_thread.hpp
+++ b/include/osmium/io/detail/read_thread.hpp
@@ -78,7 +78,7 @@ namespace osmium {
                                 break;
                             }
                             m_queue.push(std::move(data));
-                            while (m_queue.size() > 10) {
+                            while (m_queue.size() > 10 && !m_done) {
                                 std::this_thread::sleep_for(std::chrono::milliseconds(10));
                             }
                         }


### PR DESCRIPTION
Debugging https://github.com/osmcode/osmium-tool/issues/3 on Windows showed that the 
 reading thread initiated by `reader.header()` hangs sometimes when reader.close() is called. It uses the m_done variable (set to true when closing) but does not check it again when waiting in [this line](https://github.com/osmcode/libosmium/blob/master/include/osmium/io/detail/read_thread.hpp#L81)

Adding the check stopped osmium hanging decribed in https://github.com/osmcode/osmium-tool/issues/3 .
([other similar places](https://github.com/osmcode/libosmium/blob/master/include/osmium/io/detail/pbf_input_format.hpp#L600) seem to have such clause )

Other potential problem: how can the programmer be sure that m_done still exist in memory (m_done is a reference copied from m_input_done via checked_task.
