### PR TITLE
Fix travis linux build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ install:
  - sudo ln -s /usr/bin/cpp-4.8 /usr/bin/cpp
  # upgrade libosmium dependencies
  - sudo apt-get install --yes make libboost-dev libboost-program-options-dev libsparsehash-dev libprotobuf-dev protobuf-compiler libgeos++-dev libproj-dev libgdal1h libgdal-dev
- - cd ..
  - git clone https://github.com/osmcode/osm-testdata.git
  # OSMPBF is too old, install from git
  #- sudo apt-get install --yes libosmpbf-dev


### PR DESCRIPTION
This fixes a typo in the `.travis.yml` that was breaking all linux builds. All pass again after this fix.