### PR TITLE
add override keyword ...

### DIFF
--- a/include/osmium/io/detail/xml_input_format.hpp
+++ b/include/osmium/io/detail/xml_input_format.hpp
@@ -699,7 +699,7 @@ namespace osmium {
                     return buffer;
                 }
 
-                void close() {
+                void close() override {
                     m_done = true;
                     osmium::thread::wait_until_done(m_parser_future);
                 }


### PR DESCRIPTION
...to close(), overridden function in include/osmium/io/detail/input_format.hpp