### PR TITLE
GDAL 2 Support

### DIFF
--- a/include/osmium/area/problem_reporter_ogr.hpp
+++ b/include/osmium/area/problem_reporter_ogr.hpp
@@ -127,13 +127,10 @@ namespace osmium {
 
         public:
 
-            explicit ProblemReporterOGR(OGRDataSource* data_source) :
+            explicit ProblemReporterOGR(OGRDataSource* data_source, OGRSpatialReference* spatial_reference = NULL) :
                 m_data_source(data_source) {
 
-                OGRSpatialReference sparef;
-                sparef.SetWellKnownGeogCS("WGS84");
-
-                m_layer_perror = m_data_source->CreateLayer("perrors", &sparef, wkbPoint, nullptr);
+                m_layer_perror = m_data_source->CreateLayer("perrors", spatial_reference, wkbPoint, nullptr);
                 if (!m_layer_perror) {
                     std::runtime_error("Layer creation failed for layer 'perrors'");
                 }
@@ -161,7 +158,7 @@ namespace osmium {
 
                 /**************/
 
-                m_layer_lerror = m_data_source->CreateLayer("lerrors", &sparef, wkbLineString, nullptr);
+                m_layer_lerror = m_data_source->CreateLayer("lerrors", spatial_reference, wkbLineString, nullptr);
                 if (!m_layer_lerror) {
                     std::runtime_error("Layer creation failed for layer 'lerrors'");
                 }

--- a/include/osmium/geom/ogr.hpp
+++ b/include/osmium/geom/ogr.hpp
@@ -70,6 +70,7 @@ DEALINGS IN THE SOFTWARE.
 //#include <ogr_geometry.h>
 #include <ogr_api.h>
 #include <ogrsf_frmts.h>
+#include <gdal_priv.h>
 
 #ifdef _MSC_VER
 # pragma warning(pop)

--- a/test/data-tests/include/gdal_support.hpp
+++ b/test/data-tests/include/gdal_support.hpp
@@ -1,0 +1,24 @@
+#ifndef GDAL_SUPPORT_HPP
+#define GDAL_SUPPORT_HPP
+
+#if GDAL_VERSION_MAJOR < 2
+
+typedef OGRSFDriver Driver;
+typedef OGRDataSource DataSource;
+
+#define GET_DRIVER_BY_NAME(name) OGRSFDriverRegistrar::GetRegistrar()->GetDriverByName(name)
+#define CREATE_DATA_SOURCE(driver, filename, options) driver->CreateDataSource(filename, options)
+#define DESTROY_DATA_SOURCE(data_source) OGRDataSource::DestroyDataSource(data_source)
+
+#else
+
+typedef GDALDriver Driver;
+typedef GDALDataset DataSource;
+
+#define GET_DRIVER_BY_NAME(name) GetGDALDriverManager()->GetDriverByName(name)
+#define CREATE_DATA_SOURCE(driver, filename, options) driver->Create(filename, 0, 0, 0, GDT_Unknown, options)
+#define DESTROY_DATA_SOURCE(data_source) delete data_source
+
+#endif
+
+#endif // GDAL_SUPPORT_HPP

--- a/test/data-tests/testdata-overview.cpp
+++ b/test/data-tests/testdata-overview.cpp
@@ -17,6 +17,8 @@ class TestOverviewHandler : public osmium::handler::Handler {
 
     OGRDataSource* m_data_source;
 
+    OGRSpatialReference* m_spatial_reference;
+
     OGRLayer* m_layer_nodes;
     OGRLayer* m_layer_labels;
     OGRLayer* m_layer_ways;
@@ -43,12 +45,12 @@ public:
             exit(1);
         }
 
-        OGRSpatialReference sparef;
-        sparef.SetWellKnownGeogCS("WGS84");
+        m_spatial_reference = new OGRSpatialReference;
+        m_spatial_reference->SetWellKnownGeogCS("WGS84");
 
         // nodes layer
 
-        m_layer_nodes = m_data_source->CreateLayer("nodes", &sparef, wkbPoint, nullptr);
+        m_layer_nodes = m_data_source->CreateLayer("nodes", m_spatial_reference, wkbPoint, nullptr);
         if (!m_layer_nodes) {
             std::cerr << "Layer creation failed.\n";
             exit(1);
@@ -64,7 +66,7 @@ public:
 
         // labels layer
 
-        m_layer_labels = m_data_source->CreateLayer("labels", &sparef, wkbPoint, nullptr);
+        m_layer_labels = m_data_source->CreateLayer("labels", m_spatial_reference, wkbPoint, nullptr);
         if (!m_layer_labels) {
             std::cerr << "Layer creation failed.\n";
             exit(1);
@@ -88,7 +90,7 @@ public:
 
         // ways layer
 
-        m_layer_ways = m_data_source->CreateLayer("ways", &sparef, wkbLineString, nullptr);
+        m_layer_ways = m_data_source->CreateLayer("ways", m_spatial_reference, wkbLineString, nullptr);
         if (!m_layer_ways) {
             std::cerr << "Layer creation failed.\n";
             exit(1);
@@ -113,6 +115,7 @@ public:
 
     ~TestOverviewHandler() {
         OGRDataSource::DestroyDataSource(m_data_source);
+        delete m_spatial_reference;
         OGRCleanupAll();
     }
 

--- a/test/data-tests/testdata-overview.cpp
+++ b/test/data-tests/testdata-overview.cpp
@@ -10,12 +10,14 @@
 #include <osmium/io/xml_input.hpp>
 #include <osmium/visitor.hpp>
 
+#include "gdal_support.hpp"
+
 typedef osmium::index::map::SparseMemArray<osmium::unsigned_object_id_type, osmium::Location> index_type;
 typedef osmium::handler::NodeLocationsForWays<index_type> location_handler_type;
 
 class TestOverviewHandler : public osmium::handler::Handler {
 
-    OGRDataSource* m_data_source;
+    DataSource* m_data_source;
 
     OGRSpatialReference* m_spatial_reference;
 
@@ -31,7 +33,7 @@ public:
 
         OGRRegisterAll();
 
-        OGRSFDriver* driver = OGRSFDriverRegistrar::GetRegistrar()->GetDriverByName(driver_name.c_str());
+        Driver* driver = GET_DRIVER_BY_NAME(driver_name.c_str());
         if (!driver) {
             std::cerr << driver_name << " driver not available.\n";
             exit(1);
@@ -39,7 +41,7 @@ public:
 
         CPLSetConfigOption("OGR_SQLITE_SYNCHRONOUS", "FALSE");
         const char* options[] = { "SPATIALITE=TRUE", nullptr };
-        m_data_source = driver->CreateDataSource(filename.c_str(), const_cast<char**>(options));
+        m_data_source = CREATE_DATA_SOURCE(driver, filename.c_str(), const_cast<char**>(options));
         if (!m_data_source) {
             std::cerr << "Creation of output file failed.\n";
             exit(1);
@@ -114,7 +116,7 @@ public:
     }
 
     ~TestOverviewHandler() {
-        OGRDataSource::DestroyDataSource(m_data_source);
+        DESTROY_DATA_SOURCE(m_data_source);
         delete m_spatial_reference;
         OGRCleanupAll();
     }


### PR DESCRIPTION
This is more of an RFC than anything you actually want to merge just yet...

The first commit is fine, and compiled with with both GDAL 1.9 and GDAL 2.0 but the second one break 1.9 due to API incompatibilities.

What I'd like is your thoughts on the best way to support both - should we create some sort of wrapper to wrap the differences in drivers/datasources? and should that be internal for the tests or something that is part of the released libosmium?

In any case this will hopefully resolve #107 and is needed for Fedora 23 which is due out in a few months.