### PR TITLE
Cleanup cmake find module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,10 +131,12 @@ include_directories(${OSMIUM_INCLUDE_DIR})
 
 find_package(Osmium COMPONENTS io gdal geos proj sparsehash)
 
-# The find_package put the directory where it found the libosmium includes as
-# the first item in OSMIUM_INCLUDE_DIRS. We remove it again, because we want
-# to make sure to use our own include directory already set up above.
-list(REMOVE_AT OSMIUM_INCLUDE_DIRS 0)
+# The find_package put the directory where it found the libosmium includes
+# into OSMIUM_INCLUDE_DIRS. We remove it again, because we want to make
+# sure to use our own include directory already set up above.
+list(FIND OSMIUM_INCLUDE_DIRS "${OSMIUM_INCLUDE_DIR}" _own_index)
+list(REMOVE_AT OSMIUM_INCLUDE_DIRS ${_own_index})
+set(_own_index)
 
 include_directories(SYSTEM ${OSMIUM_INCLUDE_DIRS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,10 @@ else()
     message(FATAL_ERROR "PLEASE, specify the directory where the Boost library is installed in BOOST_ROOT")
 endif()
 
-include_directories(include)
+# set OSMIUM_INCLUDE_DIR so FindOsmium will not set anything different
+set(OSMIUM_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+include_directories(${OSMIUM_INCLUDE_DIR})
 
 find_package(Osmium COMPONENTS io gdal geos proj sparsehash)
 

--- a/cmake/FindOsmium.cmake
+++ b/cmake/FindOsmium.cmake
@@ -64,17 +64,13 @@ find_path(OSMIUM_INCLUDE_DIR osmium/osm.hpp
 # Handle the QUIETLY and REQUIRED arguments and set OSMIUM_FOUND to TRUE if
 # all listed variables are TRUE.
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(OSMIUM REQUIRED_VARS OSMIUM_INCLUDE_DIR)
+find_package_handle_standard_args(Osmium REQUIRED_VARS OSMIUM_INCLUDE_DIR)
 
 # Copy the results to the output variables.
 if(OSMIUM_FOUND)
     set(OSMIUM_INCLUDE_DIRS ${OSMIUM_INCLUDE_DIR})
 else()
     set(OSMIUM_INCLUDE_DIRS "")
-endif()
-
-if(Osmium_FIND_REQUIRED AND NOT OSMIUM_FOUND)
-    message(FATAL_ERROR "Can not find libosmium headers, please install them or configure the paths")
 endif()
 
 #----------------------------------------------------------------------

--- a/cmake/FindOsmium.cmake
+++ b/cmake/FindOsmium.cmake
@@ -55,13 +55,8 @@
 find_path(OSMIUM_INCLUDE_DIR osmium/osm.hpp
     PATH_SUFFIXES include
     PATHS
-        ../libosmium
-        ../../libosmium
-        libosmium
         ~/Library/Frameworks
         /Library/Frameworks
-        /usr/local
-        /usr/
         /opt/local # DarwinPorts
         /opt
 )

--- a/cmake/FindOsmium.cmake
+++ b/cmake/FindOsmium.cmake
@@ -61,18 +61,6 @@ find_path(OSMIUM_INCLUDE_DIR osmium/osm.hpp
         /opt
 )
 
-# Handle the QUIETLY and REQUIRED arguments and set OSMIUM_FOUND to TRUE if
-# all listed variables are TRUE.
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Osmium REQUIRED_VARS OSMIUM_INCLUDE_DIR)
-
-# Copy the results to the output variables.
-if(OSMIUM_FOUND)
-    set(OSMIUM_INCLUDE_DIRS ${OSMIUM_INCLUDE_DIR})
-else()
-    set(OSMIUM_INCLUDE_DIRS "")
-endif()
-
 #----------------------------------------------------------------------
 #
 #  Check for optional components
@@ -104,6 +92,7 @@ if(Osmium_USE_PBF)
     find_package(ZLIB)
     find_package(Threads)
 
+    list(APPEND OSMIUM_EXTRA_FIND_VARS ZLIB_FOUND Threads_FOUND)
     if(ZLIB_FOUND AND Threads_FOUND)
         list(APPEND OSMIUM_PBF_LIBRARIES
             ${ZLIB_LIBRARIES}
@@ -116,7 +105,6 @@ if(Osmium_USE_PBF)
             ${ZLIB_INCLUDE_DIR}
         )
     else()
-        set(_missing_libraries 1)
         message(WARNING "Osmium: Can not find some libraries for PBF input/output, please install them or configure the paths.")
     endif()
 endif()
@@ -129,6 +117,7 @@ if(Osmium_USE_XML)
     find_package(ZLIB)
     find_package(Threads)
 
+    list(APPEND OSMIUM_EXTRA_FIND_VARS EXPAT_FOUND BZIP2_FOUND ZLIB_FOUND Threads_FOUND)
     if(EXPAT_FOUND AND BZIP2_FOUND AND ZLIB_FOUND AND Threads_FOUND)
         list(APPEND OSMIUM_XML_LIBRARIES
             ${EXPAT_LIBRARIES}
@@ -142,7 +131,6 @@ if(Osmium_USE_XML)
             ${ZLIB_INCLUDE_DIR}
         )
     else()
-        set(_missing_libraries 1)
         message(WARNING "Osmium: Can not find some libraries for XML input/output, please install them or configure the paths.")
     endif()
 endif()
@@ -163,12 +151,12 @@ if(Osmium_USE_GEOS)
     find_path(GEOS_INCLUDE_DIR geos/geom.h)
     find_library(GEOS_LIBRARY NAMES geos)
 
+    list(APPEND OSMIUM_EXTRA_FIND_VARS GEOS_INCLUDE_DIR GEOS_LIBRARY)
     if(GEOS_INCLUDE_DIR AND GEOS_LIBRARY)
         SET(GEOS_FOUND 1)
         list(APPEND OSMIUM_LIBRARIES ${GEOS_LIBRARY})
         list(APPEND OSMIUM_INCLUDE_DIRS ${GEOS_INCLUDE_DIR})
     else()
-        set(_missing_libraries 1)
         message(WARNING "Osmium: GEOS library is required but not found, please install it or configure the paths.")
     endif()
 endif()
@@ -178,11 +166,11 @@ endif()
 if(Osmium_USE_GDAL)
     find_package(GDAL)
 
+    list(APPEND OSMIUM_EXTRA_FIND_VARS GDAL_FOUND)
     if(GDAL_FOUND)
         list(APPEND OSMIUM_LIBRARIES ${GDAL_LIBRARIES})
         list(APPEND OSMIUM_INCLUDE_DIRS ${GDAL_INCLUDE_DIRS})
     else()
-        set(_missing_libraries 1)
         message(WARNING "Osmium: GDAL library is required but not found, please install it or configure the paths.")
     endif()
 endif()
@@ -193,12 +181,12 @@ if(Osmium_USE_PROJ)
     find_path(PROJ_INCLUDE_DIR proj_api.h)
     find_library(PROJ_LIBRARY NAMES proj)
 
+    list(APPEND OSMIUM_EXTRA_FIND_VARS PROJ_INCLUDE_DIR PROJ_LIBRARY)
     if(PROJ_INCLUDE_DIR AND PROJ_LIBRARY)
         set(PROJ_FOUND 1)
         list(APPEND OSMIUM_LIBRARIES ${PROJ_LIBRARY})
         list(APPEND OSMIUM_INCLUDE_DIRS ${PROJ_INCLUDE_DIR})
     else()
-        set(_missing_libraries 1)
         message(WARNING "Osmium: PROJ.4 library is required but not found, please install it or configure the paths.")
     endif()
 endif()
@@ -208,6 +196,7 @@ endif()
 if(Osmium_USE_SPARSEHASH)
     find_path(SPARSEHASH_INCLUDE_DIR google/sparsetable)
 
+    list(APPEND OSMIUM_EXTRA_FIND_VARS SPARSEHASH_INCLUDE_DIR)
     if(SPARSEHASH_INCLUDE_DIR)
         # Find size of sparsetable::size_type. This does not work on older
         # CMake versions because they can do this check only in C, not in C++.
@@ -232,7 +221,6 @@ if(Osmium_USE_SPARSEHASH)
             message(WARNING "Osmium: Disabled Google SparseHash library on 32bit system (size_type=${SPARSETABLE_SIZE_TYPE}).")
         endif()
     else()
-        set(_missing_libraries 1)
         message(WARNING "Osmium: Google SparseHash library is required but not found, please install it or configure the paths.")
     endif()
 endif()
@@ -262,8 +250,18 @@ endif()
 #  Check that all required libraries are available
 #
 #----------------------------------------------------------------------
-if(Osmium_FIND_REQUIRED AND _missing_libraries)
-    message(FATAL_ERROR "Required library or libraries missing. Aborting.")
+list(REMOVE_DUPLICATES OSMIUM_EXTRA_FIND_VARS)
+# Handle the QUIETLY and REQUIRED arguments and set OSMIUM_FOUND to TRUE if
+# all listed variables are TRUE.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Osmium REQUIRED_VARS OSMIUM_INCLUDE_DIR ${OSMIUM_EXTRA_FIND_VARS})
+unset(OSMIUM_EXTRA_FIND_VARS)
+
+# Copy the results to the output variables.
+if(OSMIUM_FOUND)
+    set(OSMIUM_INCLUDE_DIRS ${OSMIUM_INCLUDE_DIR} ${OSMIUM_INCLUDE_DIRS})
+else()
+    set(OSMIUM_INCLUDE_DIRS "")
 endif()
 
 #----------------------------------------------------------------------

--- a/cmake/FindOsmium.cmake
+++ b/cmake/FindOsmium.cmake
@@ -211,18 +211,15 @@ if(Osmium_USE_SPARSEHASH)
     if(SPARSEHASH_INCLUDE_DIR)
         # Find size of sparsetable::size_type. This does not work on older
         # CMake versions because they can do this check only in C, not in C++.
-        include(CheckTypeSize)
-        set(CMAKE_REQUIRED_INCLUDES ${SPARSEHASH_INCLUDE_DIR})
-        set(CMAKE_EXTRA_INCLUDE_FILES "google/sparsetable")
-        check_type_size("google::sparsetable<int>::size_type" SPARSETABLE_SIZE_TYPE LANGUAGE CXX)
-        set(CMAKE_EXTRA_INCLUDE_FILES)
-        set(CMAKE_REQUIRED_INCLUDES)
-
-        # Falling back to checking size_t if google::sparsetable<int>::size_type
-        # could not be checked.
-        if(SPARSETABLE_SIZE_TYPE STREQUAL "")
-            check_type_size("void*" VOID_PTR_SIZE)
-            set(SPARSETABLE_SIZE_TYPE ${VOID_PTR_SIZE})
+        if (NOT CMAKE_VERSION VERSION_LESS 3.0)
+           include(CheckTypeSize)
+           set(CMAKE_REQUIRED_INCLUDES ${SPARSEHASH_INCLUDE_DIR})
+           set(CMAKE_EXTRA_INCLUDE_FILES "google/sparsetable")
+           check_type_size("google::sparsetable<int>::size_type" SPARSETABLE_SIZE_TYPE LANGUAGE CXX)
+           set(CMAKE_EXTRA_INCLUDE_FILES)
+           set(CMAKE_REQUIRED_INCLUDES)
+        else()
+           set(SPARSETABLE_SIZE_TYPE ${CMAKE_SIZEOF_VOID_P})
         endif()
 
         # Sparsetable::size_type must be at least 8 bytes (64bit), otherwise


### PR DESCRIPTION
Osmium should provide a OsmiumConfig.cmake to allow other CMake projects to integrate it easily. Until someone does it here are some cleanups and improvements to the FindOsmium.cmake.