### PR TITLE
Disable tests that fail on big endian architectures due to crc mismatches. (#112)

### DIFF
--- a/test/t/basic/test_node.cpp
+++ b/test/t/basic/test_node.cpp
@@ -7,6 +7,8 @@
 
 #include "helper.hpp"
 
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+
 TEST_CASE("Basic_Node") {
 
     osmium::CRC<boost::crc_32_type> crc32;
@@ -123,3 +125,5 @@ SECTION("tags") {
 
 
 }
+
+#endif

--- a/test/t/basic/test_relation.cpp
+++ b/test/t/basic/test_relation.cpp
@@ -7,6 +7,8 @@
 
 #include "helper.hpp"
 
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+
 TEST_CASE("Build relation") {
 
     osmium::CRC<boost::crc_32_type> crc32;
@@ -63,6 +65,8 @@ TEST_CASE("Build relation") {
     crc32.update(relation);
     REQUIRE(crc32().checksum() == 0xebcd836d);
 }
+
+#endif
 
 TEST_CASE("Member role too long") {
     osmium::memory::Buffer buffer(10000);

--- a/test/t/basic/test_way.cpp
+++ b/test/t/basic/test_way.cpp
@@ -8,6 +8,8 @@
 
 #include "helper.hpp"
 
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+
 TEST_CASE("Build way") {
 
     osmium::CRC<boost::crc_32_type> crc32;
@@ -88,3 +90,5 @@ SECTION("way_builder_with_helpers") {
 }
 
 }
+
+#endif


### PR DESCRIPTION
CRS tests are now only run on little endian architectures like `test/t/geom/test_wkb.cpp`