### PR TITLE
do not cache the version string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,7 @@ set(LIBOSMIUM_VERSION_MINOR 3)
 set(LIBOSMIUM_VERSION_PATCH 0)
 
 set(LIBOSMIUM_VERSION
-    "${LIBOSMIUM_VERSION_MAJOR}.${LIBOSMIUM_VERSION_MINOR}.${LIBOSMIUM_VERSION_PATCH}"
-    CACHE STRING
-    "Libosmium version")
+    "${LIBOSMIUM_VERSION_MAJOR}.${LIBOSMIUM_VERSION_MINOR}.${LIBOSMIUM_VERSION_PATCH}")
 
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
All components are unconditionally set before, so there is no need to put the
version string in the cache. Doing so would pin the version string in case
someone updates the source without deleting the build directory.