### PR TITLE
use decltype for lambda return type deduction in Boost if available

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -107,6 +107,10 @@ foreach(example ${EXAMPLES})
     target_link_libraries(osmium_${example} ${OSMIUM_IO_LIBRARIES} ${EXAMPLE_LIBS_${example}})
 endforeach()
 
+if (NOT CMAKE_VERSION VERSION_LESS 3.1 AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+   set_property(TARGET osmium_convert PROPERTY CXX_STANDARD 11)
+   target_compile_definitions(osmium_convert PRIVATE $<$<COMPILE_FEATURES:cxx_decltype_incomplete_return_types>:BOOST_RESULT_OF_USE_DECLTYPE>)
+endif()
 
 #-----------------------------------------------------------------------------
 message(STATUS "Configuring examples - done")


### PR DESCRIPTION
This allows osmium_convert to be build even with older Boost versions if the
compiler is new enough, otherwise one may get a build error like this:

/usr/include/boost/utility/result_of.hpp:166:8: error: no class template named ‘result’ in ‘const struct osmium::io::detail::PBFOutputFormat::relation(const osmium::Relation&)::__lambda23’
 struct result_of_nested_result : F::template result<FArgs>
        ^

This fixes #111 for me.