### PR TITLE
only enable C++ language

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo;MinSizeRel;Dev;Cover
     "List of available configuration types"
     FORCE)
 
-project(libosmium)
+project(libosmium CXX)
 
 set(LIBOSMIUM_VERSION_MAJOR 2)
 set(LIBOSMIUM_VERSION_MINOR 3)


### PR DESCRIPTION
CMake enables both C and C++ by default, but since libosmium only uses C++ code
there is no need to check for the C compiler.