### PR TITLE
remove assertion messageboxes in tests on Windows

### DIFF
--- a/test/t/util/test_file.cpp
+++ b/test/t/util/test_file.cpp
@@ -3,6 +3,7 @@
 #include <osmium/util/file.hpp>
 
 #ifdef _WIN32
+#include <crtdbg.h>
 // https://msdn.microsoft.com/en-us/library/ksazx244.aspx
 // https://msdn.microsoft.com/en-us/library/a9yf33zb.aspx
 class DoNothingInvalidParameterHandler {
@@ -23,6 +24,7 @@ public:
 
     DoNothingInvalidParameterHandler() :
         old_handler(_set_invalid_parameter_handler(invalid_parameter_handler)) {
+        _CrtSetReportMode(_CRT_ASSERT, 0);
     }
 
     ~DoNothingInvalidParameterHandler() {


### PR DESCRIPTION
When running tests on Windows I have last debug assertion windows in test_file.cpp:
https://www.dropbox.com/s/yqv6jrow0ab4fj7/2015-10-09%2012_30_35-Microsoft%20Visual%20C%2B%2B%20Runtime%20Library.png?dl=0
for tests with non-existing file descriptor. According to https://msdn.microsoft.com/en-us/library/a9yf33zb.aspx mentioned in the code, `_CrtSetReportMode(_CRT_ASSERT, 0)` is needed to prevent this crash.
(now all the debug tests pass)

