### PR TITLE
Try to flush the Buffer, then also try to grow

### DIFF
--- a/include/osmium/memory/buffer.hpp
+++ b/include/osmium/memory/buffer.hpp
@@ -548,6 +548,8 @@ namespace osmium {
                 swap(lhs.m_capacity, rhs.m_capacity);
                 swap(lhs.m_written, rhs.m_written);
                 swap(lhs.m_committed, rhs.m_committed);
+                swap(lhs.m_auto_grow, rhs.m_auto_grow);
+                swap(lhs.m_full, rhs.m_full);
             }
 
             /**

--- a/include/osmium/memory/buffer.hpp
+++ b/include/osmium/memory/buffer.hpp
@@ -367,10 +367,13 @@ namespace osmium {
              */
             unsigned char* reserve_space(const size_t size) {
                 assert(m_data);
+                // try to flush the buffer empty first.
+                if (m_written + size > m_capacity && m_full) {
+                    m_full(*this);
+                }
+                // if there's still not enough space, then try growing the buffer.
                 if (m_written + size > m_capacity) {
-                    if (m_full) {
-                        m_full(*this);
-                    } else if (!m_memory.empty() && (m_auto_grow == auto_grow::yes)) {
+                    if (!m_memory.empty() && (m_auto_grow == auto_grow::yes)) {
                         // double buffer size until there is enough space
                         size_t new_capacity = m_capacity * 2;
                         while (m_written + size > new_capacity) {

--- a/include/osmium/memory/item_iterator.hpp
+++ b/include/osmium/memory/item_iterator.hpp
@@ -217,7 +217,7 @@ namespace osmium {
             }
 
             explicit operator bool() const {
-                return m_data != nullptr;
+                return bool(m_data) && (m_data != m_end);
             }
 
             template <typename TChar, typename TTraits>


### PR DESCRIPTION
The previous implementation would call `m_full` when a reservation request would cause the buffer to overflow, but assumed that an empty buffer could hold the requested size without checking it. If the buffer is small, then this might not be the case, and the buffer would expand into potentially unallocated memory.

This implementation first tries to empty the buffer by calling `m_full` and then re-checks the size, which allows the buffer to grow if `m_auto_grow` is set appropriately.

The `m_full` and `m_auto_grow` members should be swapped in `swap`, which is fixed here. Finally, the behaviour of `item_iterator`'s `bool` conversion is updated to match the checks done before dereference, which makes it easier to check if the iterator will fail before dereferencing it.