### PR TITLE
Replace std::atof to avoid locale-dependence

### DIFF
--- a/include/osmium/io/detail/xml_input_format.hpp
+++ b/include/osmium/io/detail/xml_input_format.hpp
@@ -126,6 +126,14 @@ namespace osmium {
 
         namespace detail {
 
+            double atof_helper(const char *str) {
+              double val = 0.0f;
+              std::istringstream istr(str);
+              istr.imbue(std::locale("C"));
+              istr >> val;
+              return val;
+            }
+
             class XMLParser : public Parser {
 
                 static constexpr int buffer_size = 2 * 1000 * 1000;
@@ -253,9 +261,9 @@ namespace osmium {
 
                     check_attributes(attrs, [&location, &user, &object](const XML_Char* name, const XML_Char* value) {
                         if (!std::strcmp(name, "lon")) {
-                            location.set_lon(std::atof(value)); // XXX doesn't detect garbage after the number
+                            location.set_lon(atof_helper(value)); // XXX doesn't detect garbage after the number
                         } else if (!std::strcmp(name, "lat")) {
-                            location.set_lat(std::atof(value)); // XXX doesn't detect garbage after the number
+                            location.set_lat(atof_helper(value)); // XXX doesn't detect garbage after the number
                         } else if (!std::strcmp(name, "user")) {
                             user = value;
                         } else {
@@ -278,13 +286,13 @@ namespace osmium {
                     osmium::Location max;
                     check_attributes(attrs, [&min, &max, &user, &new_changeset](const XML_Char* name, const XML_Char* value) {
                         if (!std::strcmp(name, "min_lon")) {
-                            min.set_lon(atof(value));
+                            min.set_lon(atof_helper(value));
                         } else if (!std::strcmp(name, "min_lat")) {
-                            min.set_lat(atof(value));
+                            min.set_lat(atof_helper(value));
                         } else if (!std::strcmp(name, "max_lon")) {
-                            max.set_lon(atof(value));
+                            max.set_lon(atof_helper(value));
                         } else if (!std::strcmp(name, "max_lat")) {
-                            max.set_lat(atof(value));
+                            max.set_lat(atof_helper(value));
                         } else if (!std::strcmp(name, "user")) {
                             user = value;
                         } else {
@@ -386,13 +394,13 @@ namespace osmium {
                                 osmium::Location max;
                                 check_attributes(attrs, [&min, &max](const XML_Char* name, const XML_Char* value) {
                                     if (!std::strcmp(name, "minlon")) {
-                                        min.set_lon(atof(value));
+                                        min.set_lon(atof_helper(value));
                                     } else if (!std::strcmp(name, "minlat")) {
-                                        min.set_lat(atof(value));
+                                        min.set_lat(atof_helper(value));
                                     } else if (!std::strcmp(name, "maxlon")) {
-                                        max.set_lon(atof(value));
+                                        max.set_lon(atof_helper(value));
                                     } else if (!std::strcmp(name, "maxlat")) {
-                                        max.set_lat(atof(value));
+                                        max.set_lat(atof_helper(value));
                                     }
                                 });
                                 osmium::Box box;
@@ -424,9 +432,9 @@ namespace osmium {
                                     if (!std::strcmp(name, "ref")) {
                                         nr.set_ref(osmium::string_to_object_id(value));
                                     } else if (!std::strcmp(name, "lon")) {
-                                        nr.location().set_lon(std::atof(value)); // XXX doesn't detect garbage after the number
+                                        nr.location().set_lon(atof_helper(value)); // XXX doesn't detect garbage after the number
                                     } else if (!std::strcmp(name, "lat")) {
-                                        nr.location().set_lat(std::atof(value)); // XXX doesn't detect garbage after the number
+                                        nr.location().set_lat(atof_helper(value)); // XXX doesn't detect garbage after the number
                                     }
                                 });
                                 m_wnl_builder->add_node_ref(nr);

--- a/include/osmium/io/detail/xml_input_format.hpp
+++ b/include/osmium/io/detail/xml_input_format.hpp
@@ -126,7 +126,12 @@ namespace osmium {
 
         namespace detail {
 
-            double atof_helper(const char *str) {
+            /**
+             * Helper function to avoid using std::atof, since for std::atof,
+             * the decimal separator may not be "." (depending on the locale),
+             * leading to coordinates being cut down to their integer parts.
+             */
+            inline double atof_helper(const char *str) {
               double val = 0.0f;
               std::istringstream istr(str);
               istr.imbue(std::locale("C"));


### PR DESCRIPTION
Hi,

with std::atof, the question of what is interpreted as a decimal separator depends on the system's locale. However, the XML files always use a dot. Thus, if trying to parse such an XML file for example on a German system, all coordinates are being cut down to their integer parts.

Replacing atof with the iostream-parsing is not only "more C++", but also provides the possibility to change the locale of that specific stream to "C".