### PR TITLE
Add match_key<std::regex> tag

### DIFF
--- a/include/osmium/tags/regex_filter.hpp
+++ b/include/osmium/tags/regex_filter.hpp
@@ -42,6 +42,14 @@ namespace osmium {
 
     namespace tags {
 
+        template <> struct match_key<std::regex>
+        {
+            bool operator()(const std::regex &rule_key, const char *tag_key)
+            {
+                return std::regex_match(tag_key, rule_key);
+            }
+        }; // struct match_key<std::regex>
+
         template <>
         struct match_value<std::regex> {
             bool operator()(const std::regex& rule_value, const char* tag_value) {

--- a/test/t/tags/test_filter.cpp
+++ b/test/t/tags/test_filter.cpp
@@ -219,4 +219,19 @@ TEST_CASE("Filter") {
         check_filter(tag_list, filter, {false, true});
     }
 
+    SECTION("Filter_regex_matches_some_tags") {
+        osmium::tags::Filter<std::regex> filter(false);
+        filter.add(true, std::regex("restriction.+conditional"));
+
+        osmium::memory::Buffer buffer(10240);
+        const osmium::TagList& tag_list = make_tag_list(buffer, {
+            { "highway", "primary" },
+            { "restrictionconditional", "only_right_turn @ (Mo-Fr 07:00-14:00)" },
+            { "restriction:conditional", "only_right_turn @ (Mo-Fr 07:00-14:00)" },
+            { "restriction:psv:conditional", "only_right_turn @ (Mo-Fr 07:00-14:00)" }
+        });
+
+        check_filter(tag_list, filter, {false, false, true, true});
+    }
+
 }


### PR DESCRIPTION
Added a tag `match_key<std::regex>` for regexp key filters `osmium::tags::Filter<std::regex>`