### PR TITLE
Implements rvalue handler support for apply, resolves #180.

### DIFF
--- a/include/osmium/visitor.hpp
+++ b/include/osmium/visitor.hpp
@@ -34,6 +34,7 @@ DEALINGS IN THE SOFTWARE.
 */
 
 #include <type_traits>
+#include <utility>
 
 #include <osmium/fwd.hpp>
 #include <osmium/io/reader_iterator.hpp> // IWYU pragma: keep
@@ -54,72 +55,72 @@ namespace osmium {
         using ConstIfConst = typename std::conditional<std::is_const<T>::value, typename std::add_const<U>::type, U>::type;
 
         template <typename THandler, typename TItem>
-        inline void apply_item_recurse(TItem& item, THandler& handler) {
+        inline void apply_item_recurse(TItem& item, THandler&& handler) {
             switch (item.type()) {
                 case osmium::item_type::undefined:
                     break;
                 case osmium::item_type::node:
-                    handler.osm_object(static_cast<ConstIfConst<TItem, osmium::OSMObject>&>(item));
-                    handler.node(static_cast<ConstIfConst<TItem, osmium::Node>&>(item));
+                    std::forward<THandler>(handler).osm_object(static_cast<ConstIfConst<TItem, osmium::OSMObject>&>(item));
+                    std::forward<THandler>(handler).node(static_cast<ConstIfConst<TItem, osmium::Node>&>(item));
                     break;
                 case osmium::item_type::way:
-                    handler.osm_object(static_cast<ConstIfConst<TItem, osmium::OSMObject>&>(item));
-                    handler.way(static_cast<ConstIfConst<TItem, osmium::Way>&>(item));
+                    std::forward<THandler>(handler).osm_object(static_cast<ConstIfConst<TItem, osmium::OSMObject>&>(item));
+                    std::forward<THandler>(handler).way(static_cast<ConstIfConst<TItem, osmium::Way>&>(item));
                     break;
                 case osmium::item_type::relation:
-                    handler.osm_object(static_cast<ConstIfConst<TItem, osmium::OSMObject>&>(item));
-                    handler.relation(static_cast<ConstIfConst<TItem, osmium::Relation>&>(item));
+                    std::forward<THandler>(handler).osm_object(static_cast<ConstIfConst<TItem, osmium::OSMObject>&>(item));
+                    std::forward<THandler>(handler).relation(static_cast<ConstIfConst<TItem, osmium::Relation>&>(item));
                     break;
                 case osmium::item_type::area:
-                    handler.osm_object(static_cast<ConstIfConst<TItem, osmium::OSMObject>&>(item));
-                    handler.area(static_cast<ConstIfConst<TItem, osmium::Area>&>(item));
+                    std::forward<THandler>(handler).osm_object(static_cast<ConstIfConst<TItem, osmium::OSMObject>&>(item));
+                    std::forward<THandler>(handler).area(static_cast<ConstIfConst<TItem, osmium::Area>&>(item));
                     break;
                 case osmium::item_type::changeset:
-                    handler.changeset(static_cast<ConstIfConst<TItem, osmium::Changeset>&>(item));
+                    std::forward<THandler>(handler).changeset(static_cast<ConstIfConst<TItem, osmium::Changeset>&>(item));
                     break;
                 case osmium::item_type::tag_list:
-                    handler.tag_list(static_cast<ConstIfConst<TItem, osmium::TagList>&>(item));
+                    std::forward<THandler>(handler).tag_list(static_cast<ConstIfConst<TItem, osmium::TagList>&>(item));
                     break;
                 case osmium::item_type::way_node_list:
-                    handler.way_node_list(static_cast<ConstIfConst<TItem, osmium::WayNodeList>&>(item));
+                    std::forward<THandler>(handler).way_node_list(static_cast<ConstIfConst<TItem, osmium::WayNodeList>&>(item));
                     break;
                 case osmium::item_type::relation_member_list:
                 case osmium::item_type::relation_member_list_with_full_members:
-                    handler.relation_member_list(static_cast<ConstIfConst<TItem, osmium::RelationMemberList>&>(item));
+                    std::forward<THandler>(handler).relation_member_list(static_cast<ConstIfConst<TItem, osmium::RelationMemberList>&>(item));
                     break;
                 case osmium::item_type::outer_ring:
-                    handler.outer_ring(static_cast<ConstIfConst<TItem, osmium::OuterRing>&>(item));
+                    std::forward<THandler>(handler).outer_ring(static_cast<ConstIfConst<TItem, osmium::OuterRing>&>(item));
                     break;
                 case osmium::item_type::inner_ring:
-                    handler.inner_ring(static_cast<ConstIfConst<TItem, osmium::InnerRing>&>(item));
+                    std::forward<THandler>(handler).inner_ring(static_cast<ConstIfConst<TItem, osmium::InnerRing>&>(item));
                     break;
                 case osmium::item_type::changeset_discussion:
-                    handler.changeset_discussion(static_cast<ConstIfConst<TItem, osmium::ChangesetDiscussion>&>(item));
+                    std::forward<THandler>(handler).changeset_discussion(static_cast<ConstIfConst<TItem, osmium::ChangesetDiscussion>&>(item));
                     break;
             }
         }
 
         template <typename THandler>
-        inline void apply_item_recurse(const osmium::OSMEntity& item, THandler& handler) {
+        inline void apply_item_recurse(const osmium::OSMEntity& item, THandler&& handler) {
             switch (item.type()) {
                 case osmium::item_type::node:
-                    handler.osm_object(static_cast<const osmium::OSMObject&>(item));
-                    handler.node(static_cast<const osmium::Node&>(item));
+                  std::forward<THandler>(handler).osm_object(static_cast<const osmium::OSMObject&>(item));
+                  std::forward<THandler>(handler).node(static_cast<const osmium::Node&>(item));
                     break;
                 case osmium::item_type::way:
-                    handler.osm_object(static_cast<const osmium::OSMObject&>(item));
-                    handler.way(static_cast<const osmium::Way&>(item));
+                    std::forward<THandler>(handler).osm_object(static_cast<const osmium::OSMObject&>(item));
+                    std::forward<THandler>(handler).way(static_cast<const osmium::Way&>(item));
                     break;
                 case osmium::item_type::relation:
-                    handler.osm_object(static_cast<const osmium::OSMObject&>(item));
-                    handler.relation(static_cast<const osmium::Relation&>(item));
+                    std::forward<THandler>(handler).osm_object(static_cast<const osmium::OSMObject&>(item));
+                    std::forward<THandler>(handler).relation(static_cast<const osmium::Relation&>(item));
                     break;
                 case osmium::item_type::area:
-                    handler.osm_object(static_cast<const osmium::OSMObject&>(item));
-                    handler.area(static_cast<const osmium::Area&>(item));
+                    std::forward<THandler>(handler).osm_object(static_cast<const osmium::OSMObject&>(item));
+                    std::forward<THandler>(handler).area(static_cast<const osmium::Area&>(item));
                     break;
                 case osmium::item_type::changeset:
-                    handler.changeset(static_cast<const osmium::Changeset&>(item));
+                    std::forward<THandler>(handler).changeset(static_cast<const osmium::Changeset&>(item));
                     break;
                 default:
                     throw osmium::unknown_type();
@@ -127,26 +128,26 @@ namespace osmium {
         }
 
         template <typename THandler>
-        inline void apply_item_recurse(osmium::OSMEntity& item, THandler& handler) {
+        inline void apply_item_recurse(osmium::OSMEntity& item, THandler&& handler) {
             switch (item.type()) {
                 case osmium::item_type::node:
-                    handler.osm_object(static_cast<osmium::OSMObject&>(item));
-                    handler.node(static_cast<osmium::Node&>(item));
+                  std::forward<THandler>(handler).osm_object(static_cast<osmium::OSMObject&>(item));
+                  std::forward<THandler>(handler).node(static_cast<osmium::Node&>(item));
                     break;
                 case osmium::item_type::way:
-                    handler.osm_object(static_cast<osmium::OSMObject&>(item));
-                    handler.way(static_cast<osmium::Way&>(item));
+                    std::forward<THandler>(handler).osm_object(static_cast<osmium::OSMObject&>(item));
+                    std::forward<THandler>(handler).way(static_cast<osmium::Way&>(item));
                     break;
                 case osmium::item_type::relation:
-                    handler.osm_object(static_cast<osmium::OSMObject&>(item));
-                    handler.relation(static_cast<osmium::Relation&>(item));
+                    std::forward<THandler>(handler).osm_object(static_cast<osmium::OSMObject&>(item));
+                    std::forward<THandler>(handler).relation(static_cast<osmium::Relation&>(item));
                     break;
                 case osmium::item_type::area:
-                    handler.osm_object(static_cast<osmium::OSMObject&>(item));
-                    handler.area(static_cast<osmium::Area&>(item));
+                    std::forward<THandler>(handler).osm_object(static_cast<osmium::OSMObject&>(item));
+                    std::forward<THandler>(handler).area(static_cast<osmium::Area&>(item));
                     break;
                 case osmium::item_type::changeset:
-                    handler.changeset(static_cast<osmium::Changeset&>(item));
+                    std::forward<THandler>(handler).changeset(static_cast<osmium::Changeset&>(item));
                     break;
                 default:
                     throw osmium::unknown_type();
@@ -154,23 +155,23 @@ namespace osmium {
         }
 
         template <typename THandler>
-        inline void apply_item_recurse(const osmium::OSMObject& item, THandler& handler) {
+        inline void apply_item_recurse(const osmium::OSMObject& item, THandler&& handler) {
             switch (item.type()) {
                 case osmium::item_type::node:
-                    handler.osm_object(item);
-                    handler.node(static_cast<const osmium::Node&>(item));
+                    std::forward<THandler>(handler).osm_object(item);
+                    std::forward<THandler>(handler).node(static_cast<const osmium::Node&>(item));
                     break;
                 case osmium::item_type::way:
-                    handler.osm_object(item);
-                    handler.way(static_cast<const osmium::Way&>(item));
+                    std::forward<THandler>(handler).osm_object(item);
+                    std::forward<THandler>(handler).way(static_cast<const osmium::Way&>(item));
                     break;
                 case osmium::item_type::relation:
-                    handler.osm_object(item);
-                    handler.relation(static_cast<const osmium::Relation&>(item));
+                    std::forward<THandler>(handler).osm_object(item);
+                    std::forward<THandler>(handler).relation(static_cast<const osmium::Relation&>(item));
                     break;
                 case osmium::item_type::area:
-                    handler.osm_object(item);
-                    handler.area(static_cast<const osmium::Area&>(item));
+                    std::forward<THandler>(handler).osm_object(item);
+                    std::forward<THandler>(handler).area(static_cast<const osmium::Area&>(item));
                     break;
                 default:
                     throw osmium::unknown_type();
@@ -178,23 +179,23 @@ namespace osmium {
         }
 
         template <typename THandler>
-        inline void apply_item_recurse(osmium::OSMObject& item, THandler& handler) {
+        inline void apply_item_recurse(osmium::OSMObject& item, THandler&& handler) {
             switch (item.type()) {
                 case osmium::item_type::node:
-                    handler.osm_object(item);
-                    handler.node(static_cast<osmium::Node&>(item));
+                    std::forward<THandler>(handler).osm_object(item);
+                    std::forward<THandler>(handler).node(static_cast<osmium::Node&>(item));
                     break;
                 case osmium::item_type::way:
-                    handler.osm_object(item);
-                    handler.way(static_cast<osmium::Way&>(item));
+                    std::forward<THandler>(handler).osm_object(item);
+                    std::forward<THandler>(handler).way(static_cast<osmium::Way&>(item));
                     break;
                 case osmium::item_type::relation:
-                    handler.osm_object(item);
-                    handler.relation(static_cast<osmium::Relation&>(item));
+                    std::forward<THandler>(handler).osm_object(item);
+                    std::forward<THandler>(handler).relation(static_cast<osmium::Relation&>(item));
                     break;
                 case osmium::item_type::area:
-                    handler.osm_object(item);
-                    handler.area(static_cast<osmium::Area&>(item));
+                    std::forward<THandler>(handler).osm_object(item);
+                    std::forward<THandler>(handler).area(static_cast<osmium::Area&>(item));
                     break;
                 default:
                     throw osmium::unknown_type();
@@ -202,50 +203,50 @@ namespace osmium {
         }
 
         template <typename THandler, typename TItem, typename... TRest>
-        inline void apply_item_recurse(TItem& item, THandler& handler, TRest&... more) {
-            apply_item_recurse(item, handler);
+        inline void apply_item_recurse(TItem& item, THandler&& handler, TRest&... more) {
+            apply_item_recurse(item, std::forward<THandler>(handler));
             apply_item_recurse(item, more...);
         }
 
         template <typename THandler>
-        inline void flush_recurse(THandler& handler) {
-            handler.flush();
+        inline void flush_recurse(THandler&& handler) {
+            std::forward<THandler>(handler).flush();
         }
 
         template <typename THandler, typename... TRest>
-        inline void flush_recurse(THandler& handler, TRest&... more) {
-            flush_recurse(handler);
+        inline void flush_recurse(THandler&& handler, TRest&... more) {
+            flush_recurse(std::forward<THandler>(handler));
             flush_recurse(more...);
         }
 
     } // namespace detail
 
     template <typename... THandlers>
-    inline void apply_item(const osmium::memory::Item& item, THandlers&... handlers) {
-        detail::apply_item_recurse(item, handlers...);
+    inline void apply_item(const osmium::memory::Item& item, THandlers&&... handlers) {
+        detail::apply_item_recurse(item, std::forward<THandlers>(handlers)...);
     }
 
     template <typename... THandlers>
-    inline void apply_item(osmium::memory::Item& item, THandlers&... handlers) {
-        detail::apply_item_recurse(item, handlers...);
+    inline void apply_item(osmium::memory::Item& item, THandlers&&... handlers) {
+        detail::apply_item_recurse(item, std::forward<THandlers>(handlers)...);
     }
 
     template <typename TIterator, typename... THandlers>
-    inline void apply(TIterator it, TIterator end, THandlers&... handlers) {
+    inline void apply(TIterator it, TIterator end, THandlers&&... handlers) {
         for (; it != end; ++it) {
-            detail::apply_item_recurse(*it, handlers...);
+            detail::apply_item_recurse(*it, std::forward<THandlers>(handlers)...);
         }
-        detail::flush_recurse(handlers...);
+        detail::flush_recurse(std::forward<THandlers>(handlers)...);
     }
 
     template <typename TContainer, typename... THandlers>
-    inline void apply(TContainer& c, THandlers&... handlers) {
-        apply(std::begin(c), std::end(c), handlers...);
+    inline void apply(TContainer& c, THandlers&&... handlers) {
+        apply(std::begin(c), std::end(c), std::forward<THandlers>(handlers)...);
     }
 
     template <typename... THandlers>
-    inline void apply(const osmium::memory::Buffer& buffer, THandlers&... handlers) {
-        apply(buffer.cbegin(), buffer.cend(), handlers...);
+    inline void apply(const osmium::memory::Buffer& buffer, THandlers&&... handlers) {
+        apply(buffer.cbegin(), buffer.cend(), std::forward<THandlers>(handlers)...);
     }
 
 } // namespace osmium

--- a/test/t/io/test_reader.cpp
+++ b/test/t/io/test_reader.cpp
@@ -210,3 +210,17 @@ TEST_CASE("Reader failure modes") {
 
 }
 
+
+TEST_CASE("Applying rvalue handler on reader") {
+
+    SECTION("apply can be used with rvalue handler") {
+        osmium::io::File file(with_data_dir("t/io/data.osm"));
+        osmium::io::Reader reader(file);
+
+        struct NullHandler : public osmium::handler::Handler { };
+
+        osmium::apply(reader, NullHandler{});
+    }
+
+}
+


### PR DESCRIPTION
For #180. Perfectly forwards handlers in order to let the user specify one-off handlers in place, think:

    osmium::apply(reader, StreamPrinter{cout}};

@joto I _think_ there may be other locations in the code base where perfectly forwarding should be done. For this changeset I specifically only changed what is needed to make this use-case work.