### PR TITLE
Add docs for releasing + npm publishing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,3 +10,7 @@ Some rules for contributing to this project:
   you have added. Please read the [notes for developers](NOTES_FOR_DEVELOPERS.md)
   beforehand which contains some coding guidelines.
 
+
+### Releasing
+
+See https://github.com/osmcode/osmium-suite/blob/master/make_releases.md

--- a/include_dirs.js
+++ b/include_dirs.js
@@ -1,0 +1,2 @@
+var path = require('path');
+console.log(path.join(path.relative('.', __dirname),'include'));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "libosmium",
+    "version": "2.10.3",
+    "description": "Fast and flexible C++ library for working with OpenStreetMap data",
+    "main": "include_dirs.js",
+    "repository"   :  {
+      "type" : "git",
+      "url"  : "git://github.com/osmcode/libosmium.git"
+    },
+    "files": [
+        "include/osmium"
+    ]
+}


### PR DESCRIPTION
Because libosmium is header-only, it is very easy to include in various packaging/build systems. A common usecase at Mapbox is writing node c++ modules that depend on header-only libraries. 

Like https://github.com/mapbox/protozero/pull/59 this adds a few small things to libosmium to make it easy to:

  - publish libosmium to npm
  - allow any node addon to dynamically download and compile against the code.

This makes sense for seamless inclusion of libosmium in node modules. As a proof of concept of this usage I've written a node module that pulls in libosmium as a dependency [here](https://github.com/springmeyer/node-osmium-count/blob/2db99f458350dadab55db234c59bd797f199cce0/package.json#L17) and then dynamically builds against it [here](https://github.com/springmeyer/node-osmium-count/blob/2db99f458350dadab55db234c59bd797f199cce0/binding.gyp#L16) (possible due to the `include_dirs.js` functionality).
