### PR TITLE
Prevent windows.h from including winsock.h

### DIFF
--- a/include/osmium/util/file.hpp
+++ b/include/osmium/util/file.hpp
@@ -42,6 +42,7 @@ DEALINGS IN THE SOFTWARE.
 #include <sys/types.h>
 
 #ifdef _WIN32
+# define WIN32_LEAN_AND_MEAN // Prevent winsock.h inclusion; avoid winsock2.h conflict
 # include <io.h>
 # include <windows.h>
 #endif


### PR DESCRIPTION
By default, `windows.h` includs `winsock.h`.

Later, `osmium/io/detail/pbf.hpp` includes `winsock2.h` leading to compilation errors due to conflicting WinSock versions.

Alternatively, user has to carefully include libosmium headers to ensure `osmium/io/detail/pbf.hpp` comes before `osmium/util/file.hpp`.