### PR TITLE
Don't look up the node location if it is already known.

### DIFF
--- a/include/osmium/handler/node_locations_for_ways.hpp
+++ b/include/osmium/handler/node_locations_for_ways.hpp
@@ -155,6 +155,11 @@ namespace osmium {
                 }
                 bool error = false;
                 for (auto& node_ref : way.nodes()) {
+                    if (node_ref.location()) {
+                        // Node location is already known because the input file contained it as extra
+                        // attributes in the <nd> tag.
+                        continue;
+                    }
                     try {
                         node_ref.set_location(get_node_location(node_ref.ref()));
                         if (!node_ref.location()) {


### PR DESCRIPTION
If the input file has extra `lat` and `lon` attributes in the `<nd>` tags, this lookup is not necessary.

This fixes the following bug.

The fixed bug
-------------------

Assume the following OSM XML file (called `testfile.osm`):
```xml
<?xml version='1.0' encoding='UTF-8'?>
<osm version='0.6' upload='true' generator='vim'>
  <way id='1' visible='true'>
    <nd ref='1' lat='50.59752093205' lon='6.24685043376'/>
    <nd ref='2' lat='50.59825880818' lon='6.24848414852' />
    <nd ref='3' lat='50.59844327541' lon='6.25113108061' />
    <tag k='highway' v='secondary' />
  </way>
</osm>
```

and following Osmium program:
```c++
#include <iostream>
#include <osmium/geom/wkt.hpp>
#include <osmium/index/map/sparse_mmap_array.hpp>
#include <osmium/handler/node_locations_for_ways.hpp>
#include <osmium/io/reader.hpp>
#include <osmium/io/xml_input.hpp>
#include <osmium/osm/way.hpp>
#include <osmium/visitor.hpp>
#include <osmium/handler.hpp>

using index_type = osmium::index::map::SparseMmapArray<osmium::unsigned_object_id_type, osmium::Location>;
using location_handler_type = osmium::handler::NodeLocationsForWays<index_type>;

class MyHandler : public osmium::handler::Handler {
    osmium::geom::WKTFactory<> m_factory;

public:
    void way(const osmium::Way& way) {
        std::cout << m_factory.create_linestring(way) << "\n";
    }
};

int main(int, char**) {
    MyHandler handler;

    // This variant is necessary if you want to read OSM files which do not contain node locations on ways.
    // It does not work with files which contain node locations on ways but not the nodes themselves.
    osmium::io::Reader reader1("testfile.osm");
    try {
        index_type index;
        location_handler_type location_handler{index};
        osmium::apply(reader1, location_handler, handler);
        std::cout << "option 1 worked\n";
    } catch (osmium::not_found&) {
        std::cout << "option 1 failed\n";
    }
    reader1.close();

    // This variant is necessary if you want to read OSM files which contain node locations on ways but not the nodes themselves.
    // It does not work with files without node locations on ways because of the lacking location handler.
    osmium::io::Reader reader2("testfile.osm");
    try {
        osmium::apply(reader2, handler);
        std::cout << "option 2 worked\n";
    } catch (osmium::not_found&) {
        std::cout << "option 2 failed\n";
    }
    reader2.close();
}
```

The expected output is:
```
LINESTRING(6.2468504 50.5975209,6.2484841 50.5982588,6.2511311 50.5984433)
option 1 worked
LINESTRING(6.2468504 50.5975209,6.2484841 50.5982588,6.2511311 50.5984433)
option 2 worked
```

But I get the following using the current master branch (commit 3e0f6fc):
```
option 1 failed
LINESTRING(6.2468504 50.5975209,6.2484841 50.5982588,6.2511311 50.5984433)
option 2 worked
```

Build this example with:
```
g++ -std=c++11  -Wall -Wextra  -O3 -g -c -I /home/michael/git/libosmium/include -o waylocationstest.o waylocationstest.cpp
g++ -std=c++11  -Wall -Wextra  -O3 -g -o waylocationstest.o  waylocationstest.cpp -lexpat -lpthread -lz
```