### PR TITLE
fix CMake build if Ruby is not available

### DIFF
--- a/test/data-tests/CMakeLists.txt
+++ b/test/data-tests/CMakeLists.txt
@@ -92,7 +92,9 @@ set_tests_properties(testdata-overview PROPERTIES
 #-----------------------------------------------------------------------------
 
 find_program(RUBY ruby)
-find_package(Gem COMPONENTS json)
+if(RUBY_FOUND)
+  find_package(Gem COMPONENTS json)
+endif()
 find_program(SPATIALITE spatialite)
 
 if(RUBY AND GEM_json_FOUND AND SPATIALITE)


### PR DESCRIPTION
If there is no Ruby in the path, cmake just shows an error on finding Gems (tested on Windows). Better to skip data tests as usual.