### PR TITLE
Reduce number of warnings

### DIFF
--- a/include/osmium/util/file.hpp
+++ b/include/osmium/util/file.hpp
@@ -42,7 +42,9 @@ DEALINGS IN THE SOFTWARE.
 #include <sys/types.h>
 
 #ifdef _WIN32
-# define WIN32_LEAN_AND_MEAN // Prevent winsock.h inclusion; avoid winsock2.h conflict
+#  ifndef WIN32_LEAN_AND_MEAN
+#   define WIN32_LEAN_AND_MEAN // Prevent winsock.h inclusion; avoid winsock2.h conflict
+#  endif
 # include <io.h>
 # include <windows.h>
 #endif

--- a/include/osmium/util/string_matcher.hpp
+++ b/include/osmium/util/string_matcher.hpp
@@ -188,7 +188,7 @@ namespace osmium {
             }
 
             bool match(const char* test_string) const noexcept {
-                return std::strstr(test_string, m_str.c_str());
+                return std::strstr(test_string, m_str.c_str()) != nullptr;
             }
 
             template <typename TChar, typename TTraits>


### PR DESCRIPTION
On Windows there are many build warnings, some of them are reasonable.
First fix is about macro redefinition (in Windows-only code), second is char*-to-bool conversion:
is
```c++
return std::strstr(test_string, m_str.c_str()) != nullptr;
```
better for returning bool than
```c++
return std::strstr(test_string, m_str.c_str());
```
? 
(example: 48 to 12 warnings in osmium_tool)