### PR TITLE
Reduce number of warnings on Appveyor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,15 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${USUAL_COMPILE_OPTIONS}"
     CACHE STRING "Flags used by the compiler during RELWITHDEBINFO builds."
     FORCE)
 
+set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${USUAL_LINK_OPTIONS}"
+    CACHE STRING "Flags used by the linker during RELWITHDEBINFO builds."
+    FORCE)
+
+mark_as_advanced(
+    CMAKE_CXX_FLAGS_RELWITHDEBINFO
+    CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO
+)
+
 if(WITH_PROFILING)
     add_definitions(-fno-omit-frame-pointer)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,8 @@ endif()
 #-----------------------------------------------------------------------------
 if(MSVC)
     set(USUAL_COMPILE_OPTIONS "/Ox")
-    set(USUAL_LINK_OPTIONS "/debug")
+    # do not show warnings caused by missing .pdb files for libraries
+    set(USUAL_LINK_OPTIONS "/debug /ignore:4099")
 else()
     set(USUAL_COMPILE_OPTIONS "-O3 -g")
     set(USUAL_LINK_OPTIONS "")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,3 +24,8 @@ platform: x64
 
 build_script:
   - build-appveyor.bat
+
+# remove garbage VS messages
+# http://help.appveyor.com/discussions/problems/4569-the-target-_convertpdbfiles-listed-in-a-beforetargets-attribute-at-c-does-not-exist-in-the-project-and-will-be-ignored
+before_build:
+  - del "C:\Program Files (x86)\MSBuild\14.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets"

--- a/build-appveyor.bat
+++ b/build-appveyor.bat
@@ -101,7 +101,8 @@ msbuild libosmium.sln ^
 /p:Configuration=%config% ^
 /toolsversion:14.0 ^
 /p:Platform=x64 ^
-/p:PlatformToolset=v140
+/p:PlatformToolset=v140 ^
+/logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 ctest --output-on-failure ^

--- a/cmake/FindOsmium.cmake
+++ b/cmake/FindOsmium.cmake
@@ -333,6 +333,10 @@ if(MSVC)
     # old compilers anyway.
     add_definitions(-wd4351)
 
+    # Disable warning C4503: "decorated name length exceeded, name was truncated"
+    # there are more than 150 of generated names in libosmium longer than 4096 symbols supported in MSVC
+    add_definitions(-wd4503)
+
     add_definitions(-DNOMINMAX -DWIN32_LEAN_AND_MEAN -D_CRT_SECURE_NO_WARNINGS)
 endif()
 


### PR DESCRIPTION
There are many some unrelated warnings and garbage messages that could be easily fixed for Visual Studio builds:

- There are many missing .pdb files in dependencies back (they are too big to carry), so there were about 500 extra warnings
- There are buggy VS messages about Xamaring targets, better to have a workaround until they fix Visual Studio http://help.appveyor.com/discussions/problems/4569-the-target-_convertpdbfiles-listed-in-a-beforetargets-attribute-at-c-does-not-exist-in-the-project-and-will-be-ignored
- To disable .pdb-related warning I had to enable using USUAL_LINK_OPTIONS in RELWITHDEBUGINFO config. Hope it is OK (USUAL_LINK_OPTIONS="" on non-MS)
- Warning C4503 (name longer than 4096 symbols truncated) is too popular in libosmium (171 instances).
I thing no one will rewrite tons of code to fix it.
- Adding ``/logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"`` to msbuild provides us the nice warning list: https://ci.appveyor.com/project/alex85k/libosmium/build/1.0.4/job/yipturjuvjjcq9pk/messages 

The resulting Appveyor build log is about 1700 lines shorter and 410Kb instead of 950Kb.
