### PR TITLE
Enable use of user-provided thread::Pool instance

### DIFF
--- a/include/osmium/io/detail/debug_output_format.hpp
+++ b/include/osmium/io/detail/debug_output_format.hpp
@@ -520,8 +520,8 @@ namespace osmium {
 
             public:
 
-                DebugOutputFormat(const osmium::io::File& file, future_string_queue_type& output_queue) :
-                    OutputFormat(output_queue),
+                DebugOutputFormat(osmium::thread::Pool& pool, const osmium::io::File& file, future_string_queue_type& output_queue) :
+                    OutputFormat(pool, output_queue),
                     m_options() {
                     m_options.add_metadata   = file.is_not_false("add_metadata");
                     m_options.use_color      = file.is_true("color");
@@ -576,7 +576,7 @@ namespace osmium {
                 }
 
                 void write_buffer(osmium::memory::Buffer&& buffer) final {
-                    m_output_queue.push(osmium::thread::Pool::instance().submit(DebugOutputBlock{std::move(buffer), m_options}));
+                    m_output_queue.push(m_pool.submit(DebugOutputBlock{std::move(buffer), m_options}));
                 }
 
             }; // class DebugOutputFormat
@@ -584,8 +584,8 @@ namespace osmium {
             // we want the register_output_format() function to run, setting
             // the variable is only a side-effect, it will never be used
             const bool registered_debug_output = osmium::io::detail::OutputFormatFactory::instance().register_output_format(osmium::io::file_format::debug,
-                [](const osmium::io::File& file, future_string_queue_type& output_queue) {
-                    return new osmium::io::detail::DebugOutputFormat(file, output_queue);
+                [](osmium::thread::Pool& pool, const osmium::io::File& file, future_string_queue_type& output_queue) {
+                    return new osmium::io::detail::DebugOutputFormat(pool, file, output_queue);
             });
 
             // dummy function to silence the unused variable warning from above

--- a/include/osmium/io/detail/input_format.hpp
+++ b/include/osmium/io/detail/input_format.hpp
@@ -48,6 +48,7 @@ DEALINGS IN THE SOFTWARE.
 #include <osmium/io/header.hpp>
 #include <osmium/memory/buffer.hpp>
 #include <osmium/osm/entity_bits.hpp>
+#include <osmium/thread/pool.hpp>
 
 namespace osmium {
 
@@ -56,6 +57,7 @@ namespace osmium {
         namespace detail {
 
             struct parser_arguments {
+                osmium::thread::Pool& pool;
                 future_string_queue_type& input_queue;
                 future_buffer_queue_type& output_queue;
                 std::promise<osmium::io::Header>& header_promise;
@@ -65,6 +67,7 @@ namespace osmium {
 
             class Parser {
 
+                osmium::thread::Pool& m_pool;
                 future_buffer_queue_type& m_output_queue;
                 std::promise<osmium::io::Header>& m_header_promise;
                 queue_wrapper<std::string> m_input_queue;
@@ -73,6 +76,10 @@ namespace osmium {
                 bool m_header_is_done;
 
             protected:
+
+                osmium::thread::Pool& get_pool() {
+                    return m_pool;
+                }
 
                 std::string get_input() {
                     return m_input_queue.pop();
@@ -122,6 +129,7 @@ namespace osmium {
             public:
 
                 explicit Parser(parser_arguments& args) :
+                    m_pool(args.pool),
                     m_output_queue(args.output_queue),
                     m_header_promise(args.header_promise),
                     m_input_queue(args.input_queue),

--- a/include/osmium/io/detail/opl_output_format.hpp
+++ b/include/osmium/io/detail/opl_output_format.hpp
@@ -283,8 +283,8 @@ namespace osmium {
 
             public:
 
-                OPLOutputFormat(const osmium::io::File& file, future_string_queue_type& output_queue) :
-                    OutputFormat(output_queue),
+                OPLOutputFormat(osmium::thread::Pool& pool, const osmium::io::File& file, future_string_queue_type& output_queue) :
+                    OutputFormat(pool, output_queue),
                     m_options() {
                     m_options.add_metadata      = file.is_not_false("add_metadata");
                     m_options.locations_on_ways = file.is_true("locations_on_ways");
@@ -297,7 +297,7 @@ namespace osmium {
                 ~OPLOutputFormat() noexcept final = default;
 
                 void write_buffer(osmium::memory::Buffer&& buffer) final {
-                    m_output_queue.push(osmium::thread::Pool::instance().submit(OPLOutputBlock{std::move(buffer), m_options}));
+                    m_output_queue.push(m_pool.submit(OPLOutputBlock{std::move(buffer), m_options}));
                 }
 
             }; // class OPLOutputFormat
@@ -305,8 +305,8 @@ namespace osmium {
             // we want the register_output_format() function to run, setting
             // the variable is only a side-effect, it will never be used
             const bool registered_opl_output = osmium::io::detail::OutputFormatFactory::instance().register_output_format(osmium::io::file_format::opl,
-                [](const osmium::io::File& file, future_string_queue_type& output_queue) {
-                    return new osmium::io::detail::OPLOutputFormat(file, output_queue);
+                [](osmium::thread::Pool& pool, const osmium::io::File& file, future_string_queue_type& output_queue) {
+                    return new osmium::io::detail::OPLOutputFormat(pool, file, output_queue);
             });
 
             // dummy function to silence the unused variable warning from above

--- a/include/osmium/io/detail/pbf_input_format.hpp
+++ b/include/osmium/io/detail/pbf_input_format.hpp
@@ -183,7 +183,7 @@ namespace osmium {
                         PBFDataBlobDecoder data_blob_parser{std::move(input_buffer), read_types(), read_metadata()};
 
                         if (osmium::config::use_pool_threads_for_pbf_parsing()) {
-                            send_to_output_queue(osmium::thread::Pool::instance().submit(std::move(data_blob_parser)));
+                            send_to_output_queue(get_pool().submit(std::move(data_blob_parser)));
                         } else {
                             send_to_output_queue(data_blob_parser());
                         }

--- a/include/osmium/io/detail/pbf_output_format.hpp
+++ b/include/osmium/io/detail/pbf_output_format.hpp
@@ -434,7 +434,7 @@ namespace osmium {
 
                     primitive_block.add_message(OSMFormat::PrimitiveBlock::repeated_PrimitiveGroup_primitivegroup, m_primitive_block.group_data());
 
-                    m_output_queue.push(osmium::thread::Pool::instance().submit(
+                    m_output_queue.push(m_pool.submit(
                         SerializeBlob{std::move(primitive_block_data),
                                       pbf_blob_type::data,
                                       m_options.use_compression}
@@ -480,8 +480,8 @@ namespace osmium {
 
             public:
 
-                PBFOutputFormat(const osmium::io::File& file, future_string_queue_type& output_queue) :
-                    OutputFormat(output_queue),
+                PBFOutputFormat(osmium::thread::Pool& pool, const osmium::io::File& file, future_string_queue_type& output_queue) :
+                    OutputFormat(pool, output_queue),
                     m_options(),
                     m_primitive_block(m_options) {
                     m_options.use_dense_nodes = file.is_not_false("pbf_dense_nodes");
@@ -543,7 +543,7 @@ namespace osmium {
                         pbf_header_block.add_string(OSMFormat::HeaderBlock::optional_string_osmosis_replication_base_url, osmosis_replication_base_url);
                     }
 
-                    m_output_queue.push(osmium::thread::Pool::instance().submit(
+                    m_output_queue.push(m_pool.submit(
                         SerializeBlob{std::move(data),
                                       pbf_blob_type::header,
                                       m_options.use_compression}
@@ -643,8 +643,8 @@ namespace osmium {
             // we want the register_output_format() function to run, setting
             // the variable is only a side-effect, it will never be used
             const bool registered_pbf_output = osmium::io::detail::OutputFormatFactory::instance().register_output_format(osmium::io::file_format::pbf,
-                [](const osmium::io::File& file, future_string_queue_type& output_queue) {
-                    return new osmium::io::detail::PBFOutputFormat(file, output_queue);
+                [](osmium::thread::Pool& pool, const osmium::io::File& file, future_string_queue_type& output_queue) {
+                    return new osmium::io::detail::PBFOutputFormat(pool, file, output_queue);
             });
 
             // dummy function to silence the unused variable warning from above

--- a/include/osmium/io/detail/xml_output_format.hpp
+++ b/include/osmium/io/detail/xml_output_format.hpp
@@ -430,8 +430,8 @@ namespace osmium {
 
             public:
 
-                XMLOutputFormat(const osmium::io::File& file, future_string_queue_type& output_queue) :
-                    OutputFormat(output_queue),
+                XMLOutputFormat(osmium::thread::Pool& pool, const osmium::io::File& file, future_string_queue_type& output_queue) :
+                    OutputFormat(pool, output_queue),
                     m_options() {
                     m_options.add_metadata      = file.is_not_false("add_metadata");
                     m_options.use_change_ops    = file.is_true("xml_change_format");
@@ -474,7 +474,7 @@ namespace osmium {
                 }
 
                 void write_buffer(osmium::memory::Buffer&& buffer) final {
-                    m_output_queue.push(osmium::thread::Pool::instance().submit(XMLOutputBlock{std::move(buffer), m_options}));
+                    m_output_queue.push(m_pool.submit(XMLOutputBlock{std::move(buffer), m_options}));
                 }
 
                 void write_end() final {
@@ -494,8 +494,8 @@ namespace osmium {
             // we want the register_output_format() function to run, setting
             // the variable is only a side-effect, it will never be used
             const bool registered_xml_output = osmium::io::detail::OutputFormatFactory::instance().register_output_format(osmium::io::file_format::xml,
-                [](const osmium::io::File& file, future_string_queue_type& output_queue) {
-                    return new osmium::io::detail::XMLOutputFormat(file, output_queue);
+                [](osmium::thread::Pool& pool, const osmium::io::File& file, future_string_queue_type& output_queue) {
+                    return new osmium::io::detail::XMLOutputFormat(pool, file, output_queue);
             });
 
             // dummy function to silence the unused variable warning from above

--- a/include/osmium/io/writer.hpp
+++ b/include/osmium/io/writer.hpp
@@ -53,6 +53,7 @@ DEALINGS IN THE SOFTWARE.
 #include <osmium/io/header.hpp>
 #include <osmium/io/writer_options.hpp>
 #include <osmium/memory/buffer.hpp>
+#include <osmium/thread/pool.hpp>
 #include <osmium/thread/util.hpp>
 #include <osmium/util/config.hpp>
 #include <osmium/version.hpp>
@@ -169,7 +170,12 @@ namespace osmium {
                 osmium::io::Header header;
                 overwrite allow_overwrite = overwrite::no;
                 fsync sync = fsync::no;
+                osmium::thread::Pool* pool = nullptr;
             };
+
+            static void set_option(options_type& options, osmium::thread::Pool& pool) {
+                options.pool = &pool;
+            }
 
             static void set_option(options_type& options, const osmium::io::Header& header) {
                 options.header = header;
@@ -223,7 +229,7 @@ namespace osmium {
             explicit Writer(const osmium::io::File& file, TArgs&&... args) :
                 m_file(file.check()),
                 m_output_queue(detail::get_output_queue_size(), "raw_output"),
-                m_output(osmium::io::detail::OutputFormatFactory::instance().create_output(m_file, m_output_queue)),
+                m_output(nullptr),
                 m_buffer(),
                 m_buffer_size(default_buffer_size),
                 m_write_future(),
@@ -235,6 +241,12 @@ namespace osmium {
                 (void)std::initializer_list<int>{
                     (set_option(options, args), 0)...
                 };
+
+                if (!options.pool) {
+                    options.pool = &thread::Pool::default_instance();
+                }
+
+                m_output = osmium::io::detail::OutputFormatFactory::instance().create_output(*options.pool, m_file, m_output_queue);
 
                 if (options.header.get("generator") == "") {
                     options.header.set("generator", "libosmium/" LIBOSMIUM_VERSION_STRING);

--- a/test/data-tests/testdata-xml.cpp
+++ b/test/data-tests/testdata-xml.cpp
@@ -75,6 +75,7 @@ static std::string read_gz_file(const char* test_id, const char* suffix) {
 
 // cppcheck-suppress passedByValue
 static header_buffer_type parse_xml(std::string input) {
+    osmium::thread::Pool pool;
     osmium::io::detail::future_string_queue_type input_queue;
     osmium::io::detail::future_buffer_queue_type output_queue;
     std::promise<osmium::io::Header> header_promise;
@@ -84,6 +85,7 @@ static header_buffer_type parse_xml(std::string input) {
     osmium::io::detail::add_to_queue(input_queue, std::string{});
 
     osmium::io::detail::parser_arguments args = {
+        pool,
         input_queue,
         output_queue,
         header_promise,

--- a/test/t/io/test_reader.cpp
+++ b/test/t/io/test_reader.cpp
@@ -54,6 +54,15 @@ TEST_CASE("Reader can be initialized with string") {
     osmium::apply(reader, handler);
 }
 
+TEST_CASE("Reader can be initialized with user-provided pool") {
+    osmium::thread::Pool pool{4};
+    osmium::io::File file{with_data_dir("t/io/data.osm")};
+    osmium::io::Reader reader{file, pool};
+    osmium::handler::Handler handler;
+
+    osmium::apply(reader, handler);
+}
+
 TEST_CASE("Reader should throw after eof") {
     osmium::io::File file{with_data_dir("t/io/data.osm")};
     osmium::io::Reader reader{file};

--- a/test/t/io/test_writer.cpp
+++ b/test/t/io/test_writer.cpp
@@ -111,3 +111,40 @@ TEST_CASE("Writer") {
 
 }
 
+TEST_CASE("Writer with user-provided pool") {
+    osmium::io::Header header;
+    header.set("generator", "test_writer.cpp");
+
+    osmium::io::Reader reader{with_data_dir("t/io/data.osm")};
+    osmium::memory::Buffer buffer = reader.read();
+    REQUIRE(buffer);
+    REQUIRE(buffer.committed() > 0);
+
+    SECTION("with default number of threads") {
+        osmium::thread::Pool pool;
+        osmium::io::Writer writer{"test-writer-pool-with-default-threads.osm", pool, header, osmium::io::overwrite::allow};
+        writer(std::move(buffer));
+        writer.close();
+    }
+
+    SECTION("with negative number of threads") {
+        osmium::thread::Pool pool{-2};
+        osmium::io::Writer writer{"test-writer-pool-with-negative-threads.osm", header, pool, osmium::io::overwrite::allow};
+        writer(std::move(buffer));
+        writer.close();
+    }
+
+    SECTION("with outlier negative number of threads") {
+        osmium::thread::Pool pool{-1000};
+        osmium::io::Writer writer{"test-writer-pool-with-outlier-negative-threads.osm", header, osmium::io::overwrite::allow, pool};
+        writer(std::move(buffer));
+        writer.close();
+    }
+
+    SECTION("with outlier positive number of threads") {
+        osmium::thread::Pool pool{1000};
+        osmium::io::Writer writer{"test-writer-pool-with-outlier-positive-threads.osm", header, osmium::io::overwrite::allow, pool};
+        writer(std::move(buffer));
+        writer.close();
+    }
+}

--- a/test/t/io/test_writer_with_mock_encoder.cpp
+++ b/test/t/io/test_writer_with_mock_encoder.cpp
@@ -17,8 +17,8 @@ class MockOutputFormat : public osmium::io::detail::OutputFormat {
 
 public:
 
-    MockOutputFormat(const osmium::io::File&, osmium::io::detail::future_string_queue_type& output_queue, const std::string& fail_in) :
-        OutputFormat(output_queue),
+    MockOutputFormat(osmium::thread::Pool& pool, const osmium::io::File&, osmium::io::detail::future_string_queue_type& output_queue, const std::string& fail_in) :
+        OutputFormat(pool, output_queue),
         m_fail_in(fail_in) {
     }
 
@@ -51,8 +51,8 @@ TEST_CASE("Test Writer with MockOutputFormat") {
 
     osmium::io::detail::OutputFormatFactory::instance().register_output_format(
         osmium::io::file_format::xml,
-        [&](const osmium::io::File& file, osmium::io::detail::future_string_queue_type& output_queue) {
-            return new MockOutputFormat{file, output_queue, fail_in};
+        [&](osmium::thread::Pool& pool, const osmium::io::File& file, osmium::io::detail::future_string_queue_type& output_queue) {
+            return new MockOutputFormat{pool, file, output_queue, fail_in};
     });
 
     osmium::io::Header header;

--- a/test/t/thread/test_pool.cpp
+++ b/test/t/thread/test_pool.cpp
@@ -48,12 +48,58 @@ TEST_CASE("number of threads in pool") {
 
 }
 
+TEST_CASE("if zero number of threads requested, threads configured") {
+    osmium::thread::Pool pool{0};
+    REQUIRE(pool.num_threads() > 0);
+}
+
+TEST_CASE("if any negative number of threads requested, threads configured") {
+    osmium::thread::Pool pool{-1};
+    REQUIRE(pool.num_threads() > 0);
+}
+
+TEST_CASE("if outlier negative number of threads requested, threads configured") {
+    osmium::thread::Pool pool{-100};
+    REQUIRE(pool.num_threads() > 0);
+}
+
+TEST_CASE("if outlier positive number of threads requested, threads configured") {
+    osmium::thread::Pool pool{1000};
+    REQUIRE(pool.num_threads() > 0);
+}
+
 TEST_CASE("thread") {
 
-    auto& pool = osmium::thread::Pool::instance();
+    auto& pool = osmium::thread::Pool::default_instance();
 
     SECTION("can get access to thread pool") {
         REQUIRE(pool.queue_empty());
+    }
+
+    SECTION("can send job to thread pool") {
+        auto future = pool.submit(test_job_with_result{});
+
+        REQUIRE(future.get() == 42);
+    }
+
+    SECTION("can throw from job in thread pool") {
+        auto future = pool.submit(test_job_throw{});
+
+        REQUIRE_THROWS_AS(future.get(), const std::runtime_error&);
+    }
+
+}
+
+TEST_CASE("thread (user-provided pool)") {
+
+    osmium::thread::Pool pool{7};
+
+    SECTION("can get access to thread pool") {
+        REQUIRE(pool.queue_empty());
+    }
+    
+    SECTION("can access user-provided number of threads") {
+        REQUIRE(pool.num_threads() == 7);
     }
 
     SECTION("can send job to thread pool") {


### PR DESCRIPTION
Enable use of user-provided `thread::Pool` instance

`Pool` instance can be configured with user-specified number of threads and passed to `Reader` and `Writer` as optional argument of constructors.
If no `Pool` is specified, default instance is used and configured with number of threads based on actual number of cores on the system.

Advantages:
* Allows to use `Pool` configured with user-preferred number of threads.
* If libosmium used in a shared library, this helps to prevent potential deadlock during Pool shutdown at (after) shared library unloading (see #213 for details).

------
* Compiled with GCC 7.1.0 and passed all tests on Ubuntu Linux (complete test suite)
* Compiled with VS2017 and run using custom sample reader/writer (XML, PBF) app