### PR TITLE
Ignore _build* directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 .ycm_extra_conf.pyc
+/_build*
 /build
 /libosmium-deps
 /.vs*


### PR DESCRIPTION
The `_` prefix is handy to easily distinguish build folders it in directory listings, especially if one juggles multiple of `_build.32`, `_build.64`, `_build.clang`, etc.