### PR TITLE
Use Appveyor.MSBuildLogger on AppVeyor only

### DIFF
--- a/build-appveyor.bat
+++ b/build-appveyor.bat
@@ -97,12 +97,14 @@ ECHO calling^: %CMAKE_CMD%
 %CMAKE_CMD%
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
+SET avlogger=
+IF /I "%APPVEYOR%"=="True" SET avlogger=/logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
 msbuild libosmium.sln ^
 /p:Configuration=%config% ^
 /toolsversion:14.0 ^
 /p:Platform=x64 ^
-/p:PlatformToolset=v140 ^
-/logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+/p:PlatformToolset=v140 %avlogger%
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 ctest --output-on-failure ^


### PR DESCRIPTION
Local builds failed because of the hard coded reference to AppVeyor's custom build logger: `Appveyor.MSBuildLogger.dll`

Local builds work again and behavior on AppVeyor is as was, eg see messages here:
https://ci.appveyor.com/project/Mapbox/libosmium/build/1.0.744/job/b0nkg6jxgii9x26h/messages
