### PR TITLE
Make libosmium compatible with MSYS2 (gcc 7.2.0 on Windows)

### DIFF
--- a/include/osmium/osm/timestamp.hpp
+++ b/include/osmium/osm/timestamp.hpp
@@ -230,11 +230,11 @@ namespace osmium {
 #ifndef NDEBUG
                 auto result =
 #endif
-#ifndef _MSC_VER
-                              gmtime_r(&sse, &tm);
+#ifndef _WIN32
+                gmtime_r(&sse, &tm);
                 assert(result != nullptr);
 #else
-                              gmtime_s(&tm, &sse);
+                gmtime_s(&tm, &sse);
                 assert(result == 0);
 #endif
 

--- a/include/osmium/util/file.hpp
+++ b/include/osmium/util/file.hpp
@@ -174,7 +174,7 @@ namespace osmium {
          * @throws std::system_error If ftruncate(2) call failed
          */
         inline void resize_file(int fd, std::size_t new_size) {
-#ifdef _WIN32
+#ifdef _MSC_VER
             detail::disable_invalid_parameter_handler diph;
             // https://msdn.microsoft.com/en-us/library/whx354w1.aspx
             if (::_chsize_s(fd, static_cast_with_assert<__int64>(new_size)) != 0) {

--- a/include/osmium/util/memory_mapping.hpp
+++ b/include/osmium/util/memory_mapping.hpp
@@ -146,8 +146,8 @@ namespace osmium {
 
 #ifdef _WIN32
             HANDLE get_handle() const noexcept;
-            HANDLE osmium::util::MemoryMapping::create_file_mapping() const noexcept;
-            void* osmium::util::MemoryMapping::map_view_of_file() const noexcept;
+            HANDLE create_file_mapping() const noexcept;
+            void* map_view_of_file() const noexcept;
 #endif
 
             int resize_fd(int fd) {


### PR DESCRIPTION
As mentioned in https://github.com/osmcode/libosmium/issues/224 , both _WIN32 and _MSC_VER are used in the code to support Windows build. On Visual Studio the compiler is different and needs more workarounds (no POSIX library function). Basic _WIN32 checks are used for Unx-specific or non-C++-standard functions, like file IO and memory mapping.

However, some checks were incorrectly placed and GCC compiler on Windows (working as part of MSYS2 environment) failed to build libosmium tests and examples. Here is my attemt to fix it (Microsoft compatibility is not broken, just checked, all tests pass).