### PR TITLE
Add Msys2 building appveor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,12 +6,14 @@
 
 environment:
   matrix:
+  - config: MSYS2
+    autocrlf: true
   - config: Dev
+    autocrlf: true
+  - config: RelWithDebInfo
     autocrlf: true
   - config: Dev
     autocrlf: false
-  - config: RelWithDebInfo
-    autocrlf: true
   - config: RelWithDebInfo
     autocrlf: false
 
@@ -25,13 +27,26 @@ init:
   - git config --global core.autocrlf %autocrlf%
   - git config --get core.autocrlf
 
+install:
+  -  cd c:\projects
+  -  git clone https://github.com/osmcode/osm-testdata
+  -  if [%config%]==[MSYS2] (
+        C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh --sysupgrade --sysupgrade
+       && C:\msys64\usr\bin\pacman -Rc --noconfirm mingw-w64-x86_64-gcc-libs
+     )
+
 # clone directory
 clone_folder: c:\projects\libosmium
 
 platform: x64
 
 build_script:
-  - build-appveyor.bat
+  -  cd c:\projects\libosmium
+  - if [%config%]==[MSYS2] (
+        build-msys2.bat
+    ) else (
+        build-appveyor.bat
+    )
 
 # remove garbage VS messages
 # http://help.appveyor.com/discussions/problems/4569-the-target-_convertpdbfiles-listed-in-a-beforetargets-attribute-at-c-does-not-exist-in-the-project-and-will-be-ignored

--- a/build-msys2.bat
+++ b/build-msys2.bat
@@ -1,0 +1,22 @@
+echo "Adding MSYS2 to path..."
+SET "PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%"
+echo %PATH%
+
+echo "Installing MSYS2 packages..."
+bash -lc "pacman -S --needed --noconfirm mingw-w64-x86_64-gcc mingw-w64-x86_64-geos mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-cppcheck mingw-w64-x86_64-doxygen mingw-w64-x86_64-gdb  mingw-w64-x86_64-sparsehash mingw-w64-x86_64-gdal mingw-w64-x86_64-ruby mingw-w64-x86_64-libspatialite mingw-w64-x86_64-spatialite-tools mingw-w64-x86_64-clang-tools-extra"
+bash -lc "pacman -S --needed --noconfirm mingw-w64-x86_64-postgresql mingw-w64-x86_64-netcdf mingw-w64-x86_64-crypto++"
+call C:\msys64\mingw64\bin\gem.cmd install json
+
+echo "Setting PROJ_LIB variable for correct PROJ.4 working"
+set PROJ_LIB=c:\msys64\mingw64\share\proj
+
+echo "Generating makefiles"
+mkdir build
+cd build
+cmake .. -G "MSYS Makefiles" -DBUILD_DATA_TESTS=ON -DBUILD_HEADERS=OFF
+
+echo "Building"
+make
+
+echo "Testing"
+ctest

--- a/cmake/FindGem.cmake
+++ b/cmake/FindGem.cmake
@@ -1,5 +1,7 @@
 # Author thomas.roehr@dfki.de
 #
+# Version 0.31 2017-09-15
+#       - find gem executable gem.cmd on Windows
 # Version 0.3 2013-07-02
 #       - rely on `gem content` to find library and header
 #       - introduce GEM_OS_PKG to allow search via pkgconfig
@@ -28,7 +30,7 @@
 # Check for how 'gem' should be called
 include(FindPackageHandleStandardArgs)
 find_program(GEM_EXECUTABLE
-    NAMES "gem${RUBY_VERSION_MAJOR}${RUBY_VERSION_MINOR}"
+    NAMES "gem.cmd" "gem${RUBY_VERSION_MAJOR}${RUBY_VERSION_MINOR}"
         "gem${RUBY_VERSION_MAJOR}.${RUBY_VERSION_MINOR}"
         "gem-${RUBY_VERSION_MAJOR}${RUBY_VERSION_MINOR}"
         "gem-${RUBY_VERSION_MAJOR}.${RUBY_VERSION_MINOR}"


### PR DESCRIPTION
Following https://github.com/osmcode/libosmium/issues/224  and https://github.com/osmcode/libosmium/pull/226

Here is the build on Windows with latest MinGW compiler provided by MSYS2 project. The dependencies are also provied and downloaded as binary pacakages (may be updating, versions are not fixed).

I have also found a source of minor problem with not-finding json ruby gem - gem executable was called gem.cmd and was not found with FindGem.cmake.
With current version of MSYS2 packages all the tests should pass.