### PR TITLE
Fix testdata-multipolygon test on Windows (executable path differs)

### DIFF
--- a/test/data-tests/CMakeLists.txt
+++ b/test/data-tests/CMakeLists.txt
@@ -110,6 +110,7 @@ if(RUBY AND GEM_json_FOUND AND SPATIALITE)
             COMMAND ${CMAKE_COMMAND}
                 -D OSM_TESTDATA=${OSM_TESTDATA}
                 -D RUBY=${RUBY}
+                -D EXECUTABLE=$<TARGET_FILE:testdata-multipolygon>
                 -P ${CMAKE_CURRENT_SOURCE_DIR}/run-testdata-multipolygon.cmake)
 
     set_tests_properties(testdata-multipolygon PROPERTIES LABELS "data;slow")

--- a/test/data-tests/run-testdata-multipolygon.cmake
+++ b/test/data-tests/run-testdata-multipolygon.cmake
@@ -14,8 +14,7 @@ file(REMOVE multipolygon.db multipolygon-tests.json)
 #
 #-----------------------------------------------------------------------------
 execute_process(
-    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/testdata-multipolygon
-        ${OSM_TESTDATA}/grid/data/all.osm
+    COMMAND ${EXECUTABLE} ${OSM_TESTDATA}/grid/data/all.osm
     RESULT_VARIABLE _result
     OUTPUT_FILE multipolygon.log
     ERROR_FILE multipolygon.log


### PR DESCRIPTION
Noticed that for MSVC builds the testsdata-multipolygon test failed (previously it was not run because of gem finding bug). The reason was /Release/ folder in test executable path (tests are run with `ctest -VV -C Release` but our manual code did not use that rare option). So the solution proposed is to pass EXECUTABLE parameter to run-testdata-multipolygon.cmake . Should make appveyor even more happy :)