### PR TITLE
No winsock dependency

### DIFF
--- a/cmake/FindOsmium.cmake
+++ b/cmake/FindOsmium.cmake
@@ -131,10 +131,6 @@ if(Osmium_USE_PBF)
             ${ZLIB_LIBRARIES}
             ${CMAKE_THREAD_LIBS_INIT}
         )
-        if(WIN32)
-            # This is needed for the ntohl() function
-            list(APPEND OSMIUM_PBF_LIBRARIES ws2_32)
-        endif()
         list(APPEND OSMIUM_INCLUDE_DIRS
             ${ZLIB_INCLUDE_DIR}
             ${PROTOZERO_INCLUDE_DIR}

--- a/include/osmium/io/detail/pbf.hpp
+++ b/include/osmium/io/detail/pbf.hpp
@@ -36,11 +36,11 @@ DEALINGS IN THE SOFTWARE.
 #include <cstdint>
 #include <string>
 
-// needed for htonl and ntohl
+// needed for htonl and ntohl or their equivalent in protozero
 #ifndef _WIN32
 # include <netinet/in.h>
 #else
-# include <winsock2.h>
+# include <protozero/byteswap.hpp>
 #endif
 
 #include <osmium/io/error.hpp>

--- a/include/osmium/io/detail/pbf_input_format.hpp
+++ b/include/osmium/io/detail/pbf_input_format.hpp
@@ -105,7 +105,13 @@ namespace osmium {
                         return 0; // EOF
                     }
 
+                    #ifndef _WIN32
                     const uint32_t size = ntohl(size_in_network_byte_order);
+                    #else
+                    uint32_t size = size_in_network_byte_order;
+                    protozero::detail::byteswap_inplace(&size);
+                    #endif
+
                     if (size > static_cast<uint32_t>(max_blob_header_size)) {
                         throw osmium::pbf_error{"invalid BlobHeader size (> max_blob_header_size)"};
                     }

--- a/include/osmium/io/detail/pbf_output_format.hpp
+++ b/include/osmium/io/detail/pbf_output_format.hpp
@@ -185,7 +185,12 @@ namespace osmium {
                     pbf_blob_header.add_string(FileFormat::BlobHeader::required_string_type, m_blob_type == pbf_blob_type::data ? "OSMData" : "OSMHeader");
                     pbf_blob_header.add_int32(FileFormat::BlobHeader::required_int32_datasize, static_cast_with_assert<int32_t>(blob_data.size()));
 
+                    #ifndef _WIN32
                     const uint32_t sz = htonl(static_cast_with_assert<uint32_t>(blob_header_data.size()));
+                    #else
+                    uint32_t sz = static_cast_with_assert<uint32_t>(blob_header_data.size());
+                    protozero::detail::byteswap_inplace(&sz);
+                    #endif
 
                     // write to output: the 4-byte BlobHeader-Size followed by the BlobHeader followed by the Blob
                     std::string output;

--- a/test/data-tests/CMakeLists.txt
+++ b/test/data-tests/CMakeLists.txt
@@ -110,6 +110,7 @@ if(RUBY AND GEM_json_FOUND AND SPATIALITE)
             COMMAND ${CMAKE_COMMAND}
                 -D OSM_TESTDATA=${OSM_TESTDATA}
                 -D RUBY=${RUBY}
+                -D EXECUTABLE=$<TARGET_FILE:testdata-multipolygon>
                 -P ${CMAKE_CURRENT_SOURCE_DIR}/run-testdata-multipolygon.cmake)
 
     set_tests_properties(testdata-multipolygon PROPERTIES LABELS "data;slow")

--- a/test/data-tests/run-testdata-multipolygon.cmake
+++ b/test/data-tests/run-testdata-multipolygon.cmake
@@ -14,8 +14,7 @@ file(REMOVE multipolygon.db multipolygon-tests.json)
 #
 #-----------------------------------------------------------------------------
 execute_process(
-    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/testdata-multipolygon
-        ${OSM_TESTDATA}/grid/data/all.osm
+    COMMAND ${EXECUTABLE} ${OSM_TESTDATA}/grid/data/all.osm
     RESULT_VARIABLE _result
     OUTPUT_FILE multipolygon.log
     ERROR_FILE multipolygon.log


### PR DESCRIPTION
Many warnings and previous build problems were related to winsock2 library we used. But currently the only place where it is needed is byte order conversion https://github.com/osmcode/libosmium/blob/381cf92723a1fab5b1fc74fcb8f0ad89d73b7274/include/osmium/io/detail/pbf_output_format.hpp#L188
Now that we have protozero library, this can easily be avoided, at least on Windows (little-endian only).