### PR TITLE
Add polygon implementation for WKT and GeoJSON Geometry Factories

### DIFF
--- a/include/osmium/geom/geojson.hpp
+++ b/include/osmium/geom/geojson.hpp
@@ -98,6 +98,28 @@ namespace osmium {
                     return str;
                 }
 
+                /* Polygon */
+                void polygon_start() {
+                    m_str = "{\"type\":\"Polygon\",\"coordinates\":[[";
+                }
+
+                void polygon_add_location(const osmium::geom::Coordinates& xy) {
+                    xy.append_to_string(m_str, '[', ',', ']', m_precision);
+                    m_str += ',';
+                }
+
+                polygon_type polygon_finish(size_t /* num_points */) {
+                    assert(!m_str.empty());
+                    std::string str;
+
+                    using std::swap;
+                    swap(str, m_str);
+
+                    str.back() = ']';
+                    str += "]}";
+                    return str;
+                }
+
                 /* MultiPolygon */
 
                 void multipolygon_start() {

--- a/include/osmium/geom/wkt.hpp
+++ b/include/osmium/geom/wkt.hpp
@@ -110,6 +110,29 @@ namespace osmium {
                     return str;
                 }
 
+                /* Polygon */
+                void polygon_start() {
+                    m_str = m_srid_prefix;
+                    m_str += "POLYGON((";
+                }
+
+                void polygon_add_location(const osmium::geom::Coordinates& xy) {
+                    xy.append_to_string(m_str, ' ', m_precision);
+                    m_str += ',';
+                }
+
+                polygon_type polygon_finish(size_t /* num_points */) {
+                    assert(!m_str.empty());
+                    std::string str;
+
+                    using std::swap;
+                    swap(str, m_str);
+
+                    str.back() = ')';
+                    str += ")";
+                    return str;
+                }
+
                 /* MultiPolygon */
 
                 void multipolygon_start() {

--- a/test/t/geom/test_geojson.cpp
+++ b/test/t/geom/test_geojson.cpp
@@ -80,6 +80,32 @@ TEST_CASE("GeoJSON linestring geometry") {
 
 }
 
+TEST_CASE("GeoJSON polygon geometry") {
+    osmium::geom::GeoJSONFactory<> factory;
+    osmium::memory::Buffer buffer{1000};
+    const auto& wnl = create_test_wnl_closed(buffer);
+
+    SECTION("unique forwards (default)") {
+      const std::string wkt{factory.create_polygon(wnl)};
+      REQUIRE(wkt == "{\"type\":\"Polygon\",\"coordinates\":[[[3,3],[4.1,4.1],[3.6,4.1],[3.1,3.5],[3,3]]]}");
+    }
+
+    SECTION("unique backwards") {
+      const std::string wkt{factory.create_polygon(wnl, osmium::geom::use_nodes::unique, osmium::geom::direction::backward)};
+      REQUIRE(wkt == "{\"type\":\"Polygon\",\"coordinates\":[[[3,3],[3.1,3.5],[3.6,4.1],[4.1,4.1],[3,3]]]}");
+    }
+
+    SECTION("all forwards") {
+      const std::string wkt{factory.create_polygon(wnl,  osmium::geom::use_nodes::all)};
+      REQUIRE(wkt == "{\"type\":\"Polygon\",\"coordinates\":[[[3,3],[4.1,4.1],[4.1,4.1],[3.6,4.1],[3.1,3.5],[3,3]]]}");
+    }
+
+    SECTION("all backwards") {
+      const std::string wkt{factory.create_polygon(wnl, osmium::geom::use_nodes::all, osmium::geom::direction::backward)};
+      REQUIRE(wkt == "{\"type\":\"Polygon\",\"coordinates\":[[[3,3],[3.1,3.5],[3.6,4.1],[4.1,4.1],[4.1,4.1],[3,3]]]}");
+    }
+}
+
 TEST_CASE("GeoJSON area geometry") {
     osmium::geom::GeoJSONFactory<> factory;
     osmium::memory::Buffer buffer{1000};

--- a/test/t/geom/test_wkt.cpp
+++ b/test/t/geom/test_wkt.cpp
@@ -60,6 +60,30 @@ TEST_CASE("WKT geometry factory") {
         }
     }
 
+    SECTION("polygon") {
+        const auto& wnl = create_test_wnl_closed(buffer);
+
+        SECTION("unique forwards (default)") {
+            const std::string wkt{factory.create_polygon(wnl)};
+            REQUIRE(wkt == "POLYGON((3 3,4.1 4.1,3.6 4.1,3.1 3.5,3 3))");
+        }
+
+        SECTION("unique backwards") {
+            const std::string wkt{factory.create_polygon(wnl, osmium::geom::use_nodes::unique, osmium::geom::direction::backward)};
+            REQUIRE(wkt == "POLYGON((3 3,3.1 3.5,3.6 4.1,4.1 4.1,3 3))");
+        }
+
+        SECTION("all forwards") {
+            const std::string wkt{factory.create_polygon(wnl,  osmium::geom::use_nodes::all)};
+            REQUIRE(wkt == "POLYGON((3 3,4.1 4.1,4.1 4.1,3.6 4.1,3.1 3.5,3 3))");
+        }
+
+        SECTION("all backwards") {
+            const std::string wkt{factory.create_polygon(wnl, osmium::geom::use_nodes::all, osmium::geom::direction::backward)};
+            REQUIRE(wkt == "POLYGON((3 3,3.1 3.5,3.6 4.1,4.1 4.1,4.1 4.1,3 3))");
+        }
+    }
+
     SECTION("empty linestring") {
         const auto& wnl = create_test_wnl_empty(buffer);
 

--- a/test/t/geom/wnl_helper.hpp
+++ b/test/t/geom/wnl_helper.hpp
@@ -16,6 +16,19 @@ inline const osmium::WayNodeList& create_test_wnl_okay(osmium::memory::Buffer& b
     return buffer.get<osmium::WayNodeList>(pos);
 }
 
+inline const osmium::WayNodeList& create_test_wnl_closed(osmium::memory::Buffer& buffer) {
+    const auto pos = osmium::builder::add_way_node_list(buffer, _nodes({
+        {1, {3.0, 3.0}},
+        {2, {4.1, 4.1}},
+        {3, {4.1, 4.1}},
+        {4, {3.6, 4.1}},
+        {5, {3.1, 3.5}},
+        {6, {3.0, 3.0}},
+    }));
+
+    return buffer.get<osmium::WayNodeList>(pos);
+}
+
 inline const osmium::WayNodeList& create_test_wnl_empty(osmium::memory::Buffer& buffer) {
     {
         osmium::builder::WayNodeListBuilder wnl_builder(buffer);


### PR DESCRIPTION
I was trying to use these classes in another project and noticed there did not seem to be an implementation of the various Polygon handler methods for the WKT and GeoJSON writers. I'm afraid I don't have an exact example of the error this produces available any more but roughly the WKT or GeoJSON writer would error out because there is no polygon_start implementation included. I added the necessary methods for this along with test cases to cover them.

It's worth noting that the one I added so far is a fairly naive Polygon implementation in that it does not expect any of the geometries to include interior rings. However based on my understanding of how OSM represents these geometries I think this is OK since those would always be handled as Areas and thus get serialized as MultiPolygons anyway.