### PR TITLE
Object comparison without timestamp

### DIFF
--- a/include/osmium/osm/object.hpp
+++ b/include/osmium/osm/object.hpp
@@ -476,8 +476,10 @@ namespace osmium {
      * ordering.
      */
     inline bool operator<(const OSMObject& lhs, const OSMObject& rhs) noexcept {
-        return const_tie(lhs.type(), lhs.id() > 0, lhs.positive_id(), lhs.version(), lhs.timestamp()) <
-               const_tie(rhs.type(), rhs.id() > 0, rhs.positive_id(), rhs.version(), rhs.timestamp());
+        return const_tie(lhs.type(), lhs.id() > 0, lhs.positive_id(), lhs.version(),
+                   ((lhs.timestamp().valid() && rhs.timestamp().valid()) ? lhs.timestamp() : osmium::Timestamp())) <
+               const_tie(rhs.type(), rhs.id() > 0, rhs.positive_id(), rhs.version(),
+                   ((lhs.timestamp().valid() && rhs.timestamp().valid()) ? rhs.timestamp() : osmium::Timestamp()));
     }
 
     inline bool operator>(const OSMObject& lhs, const OSMObject& rhs) noexcept {

--- a/include/osmium/osm/object_comparisons.hpp
+++ b/include/osmium/osm/object_comparisons.hpp
@@ -157,28 +157,6 @@ namespace osmium {
 
     }; // struct object_order_type_id_reverse_version
 
-    /**
-     * Function object class for ordering OSM objects by type, id, and reverse
-     * version.
-     *
-     * The naming is a bit awkward here, but necessary to keep backwards
-     * compatibility with object_order_type_id_reverse_version.
-     */
-    struct object_order_type_id_reverse_version_without_timestamp {
-
-        bool operator()(const osmium::OSMObject& lhs, const osmium::OSMObject& rhs) const noexcept {
-            return const_tie(lhs.type(), lhs.id() > 0, lhs.positive_id(), rhs.version()) <
-                   const_tie(rhs.type(), rhs.id() > 0, rhs.positive_id(), lhs.version());
-        }
-
-        /// @pre lhs and rhs must not be nullptr
-        bool operator()(const osmium::OSMObject* lhs, const osmium::OSMObject* rhs) const noexcept {
-            assert(lhs && rhs);
-            return operator()(*lhs, *rhs);
-        }
-
-    }; // struct object_order_type_id_reverse_version_without_timestamp
-
 } // namespace osmium
 
 #endif // OSMIUM_OSM_OBJECT_COMPARISONS_HPP

--- a/include/osmium/osm/object_comparisons.hpp
+++ b/include/osmium/osm/object_comparisons.hpp
@@ -143,8 +143,10 @@ namespace osmium {
     struct object_order_type_id_reverse_version {
 
         bool operator()(const osmium::OSMObject& lhs, const osmium::OSMObject& rhs) const noexcept {
-            return const_tie(lhs.type(), lhs.id() > 0, lhs.positive_id(), rhs.version(), rhs.timestamp()) <
-                   const_tie(rhs.type(), rhs.id() > 0, rhs.positive_id(), lhs.version(), lhs.timestamp());
+            return const_tie(lhs.type(), lhs.id() > 0, lhs.positive_id(), rhs.version(),
+                        ((lhs.timestamp().valid() && rhs.timestamp().valid()) ? rhs.timestamp() : osmium::Timestamp())) <
+                   const_tie(rhs.type(), rhs.id() > 0, rhs.positive_id(), lhs.version(),
+                        ((lhs.timestamp().valid() && rhs.timestamp().valid()) ? lhs.timestamp() : osmium::Timestamp()));
         }
 
         /// @pre lhs and rhs must not be nullptr

--- a/test/t/osm/test_object_comparisons.cpp
+++ b/test/t/osm/test_object_comparisons.cpp
@@ -140,3 +140,22 @@ TEST_CASE("Object comparisons: types are ordered nodes, then ways, then relation
     REQUIRE(std::is_sorted(objects.cbegin(), objects.cend()));
 }
 
+TEST_CASE("Object comparisons with partially missing timestamp") {
+    osmium::memory::Buffer buffer{10 * 1000};
+    osmium::OSMObject& obj1 = buffer.get<osmium::Node>(    osmium::builder::add_node(    buffer,
+            _id(3), _version(2), _timestamp(("2016-01-01T00:00:00Z"))));
+    osmium::OSMObject& obj2 = buffer.get<osmium::Node>(    osmium::builder::add_node(    buffer,
+            _id(3), _version(2)));
+
+    SECTION("OSMObject::operator<") {
+        REQUIRE_FALSE(obj1 < obj2);
+        REQUIRE_FALSE(obj1 > obj2);
+        REQUIRE(obj1 == obj2);
+    }
+
+    SECTION("object_order_type_id_reverse_version") {
+        const osmium::object_order_type_id_reverse_version comp{};
+        REQUIRE_FALSE(comp(obj1, obj2));
+        REQUIRE_FALSE(comp(obj2, obj1));
+    }
+}


### PR DESCRIPTION
Changes:

* Remove object_order_type_id_reverse_version_without_timestamp
* Ignore the timestamp when comparing objects if one object does not have a valid timestamp. Invalid timestamps are internally stored as 0 and lead to wrong results when `operator<` is called. This makes some fixes in Osmium Tool (https://github.com/osmcode/osmium-tool/pull/87, https://github.com/osmcode/osmium-tool/pull/88, https://github.com/osmcode/osmium-tool/pull/94) easier because their code changes can be rejected and only their new unit tests merged into master.