### PR TITLE
Add option use_default_metadata_values

### DIFF
--- a/include/osmium/io/detail/pbf_output_format.hpp
+++ b/include/osmium/io/detail/pbf_output_format.hpp
@@ -87,6 +87,9 @@ namespace osmium {
                 /// Which metadata of objects should be added?
                 osmium::metadata_options add_metadata;
 
+                /// Write zeros to those metadata fields which should not be written?
+                bool default_metadata_values = false;
+
                 /// Should nodes be encoded in DenseNodes?
                 bool use_dense_nodes = true;
 
@@ -285,18 +288,28 @@ namespace osmium {
 
                     if (m_options.add_metadata.version()) {
                         m_versions.push_back(static_cast_with_assert<int32_t>(node.version()));
+                    } else if (m_options.default_metadata_values) {
+                        m_versions.push_back(0);
                     }
                     if (m_options.add_metadata.timestamp()) {
                         m_timestamps.push_back(m_delta_timestamp.update(uint32_t(node.timestamp())));
+                    } else if (m_options.default_metadata_values) {
+                        m_timestamps.push_back(m_delta_timestamp.update(uint32_t(osmium::Timestamp())));
                     }
                     if (m_options.add_metadata.changeset()) {
                         m_changesets.push_back(m_delta_changeset.update(node.changeset()));
+                    } else if (m_options.default_metadata_values) {
+                        m_changesets.push_back(m_delta_changeset.update(0));
                     }
                     if (m_options.add_metadata.uid()) {
                         m_uids.push_back(m_delta_uid.update(node.uid()));
+                    } else if (m_options.default_metadata_values) {
+                        m_uids.push_back(m_delta_uid.update(0));
                     }
                     if (m_options.add_metadata.user()) {
                         m_user_sids.push_back(m_delta_user_sid.update(m_stringtable.add(node.user())));
+                    } else if (m_options.default_metadata_values) {
+                        m_user_sids.push_back(m_delta_user_sid.update(m_stringtable.add("")));
                     }
                     if (m_options.add_visible_flag) {
                         m_visibles.push_back(node.visible());
@@ -318,21 +331,21 @@ namespace osmium {
 
                     pbf_dense_nodes.add_packed_sint64(OSMFormat::DenseNodes::packed_sint64_id, m_ids.cbegin(), m_ids.cend());
 
-                    if (m_options.add_metadata.any() || m_options.add_visible_flag) {
+                    if (m_options.add_metadata.any() || m_options.add_visible_flag || m_options.default_metadata_values) {
                         protozero::pbf_builder<OSMFormat::DenseInfo> pbf_dense_info{pbf_dense_nodes, OSMFormat::DenseNodes::optional_DenseInfo_denseinfo};
-                        if (m_options.add_metadata.version()) {
+                        if (m_options.add_metadata.version() || m_options.default_metadata_values) {
                             pbf_dense_info.add_packed_int32(OSMFormat::DenseInfo::packed_int32_version, m_versions.cbegin(), m_versions.cend());
                         }
-                        if (m_options.add_metadata.timestamp()) {
+                        if (m_options.add_metadata.timestamp() || m_options.default_metadata_values) {
                             pbf_dense_info.add_packed_sint64(OSMFormat::DenseInfo::packed_sint64_timestamp, m_timestamps.cbegin(), m_timestamps.cend());
                         }
-                        if (m_options.add_metadata.changeset()) {
+                        if (m_options.add_metadata.changeset() || m_options.default_metadata_values) {
                             pbf_dense_info.add_packed_sint64(OSMFormat::DenseInfo::packed_sint64_changeset, m_changesets.cbegin(), m_changesets.cend());
                         }
-                        if (m_options.add_metadata.uid()) {
+                        if (m_options.add_metadata.uid() || m_options.default_metadata_values) {
                             pbf_dense_info.add_packed_sint32(OSMFormat::DenseInfo::packed_sint32_uid, m_uids.cbegin(), m_uids.cend());
                         }
-                        if (m_options.add_metadata.user()) {
+                        if (m_options.add_metadata.user() || m_options.default_metadata_values) {
                             pbf_dense_info.add_packed_sint32(OSMFormat::DenseInfo::packed_sint32_user_sid, m_user_sids.cbegin(), m_user_sids.cend());
                         }
                         if (m_options.add_visible_flag) {
@@ -477,23 +490,33 @@ namespace osmium {
                         }
                     }
 
-                    if (m_options.add_metadata.any() || m_options.add_visible_flag) {
+                    if (m_options.add_metadata.any() || m_options.add_visible_flag || m_options.default_metadata_values) {
                         protozero::pbf_builder<OSMFormat::Info> pbf_info{pbf_object, T::enum_type::optional_Info_info};
 
                         if (m_options.add_metadata.version()) {
                             pbf_info.add_int32(OSMFormat::Info::optional_int32_version, static_cast_with_assert<int32_t>(object.version()));
+                        } else if (m_options.default_metadata_values) {
+                            pbf_info.add_int32(OSMFormat::Info::optional_int32_version, 0);
                         }
                         if (m_options.add_metadata.timestamp()) {
                             pbf_info.add_int64(OSMFormat::Info::optional_int64_timestamp, uint32_t(object.timestamp()));
+                        } else if (m_options.default_metadata_values) {
+                            pbf_info.add_int64(OSMFormat::Info::optional_int64_timestamp, uint32_t(osmium::Timestamp()));
                         }
                         if (m_options.add_metadata.changeset()) {
                             pbf_info.add_int64(OSMFormat::Info::optional_int64_changeset, object.changeset());
+                        } else if (m_options.default_metadata_values) {
+                            pbf_info.add_int64(OSMFormat::Info::optional_int64_changeset, 0);
                         }
                         if (m_options.add_metadata.uid()) {
                             pbf_info.add_int32(OSMFormat::Info::optional_int32_uid, static_cast_with_assert<int32_t>(object.uid()));
+                        } else if (m_options.default_metadata_values) {
+                            pbf_info.add_int32(OSMFormat::Info::optional_int32_uid, 0);
                         }
                         if (m_options.add_metadata.user()) {
                             pbf_info.add_uint32(OSMFormat::Info::optional_uint32_user_sid, m_primitive_block.store_in_stringtable(object.user()));
+                        } else if (m_options.default_metadata_values) {
+                            pbf_info.add_uint32(OSMFormat::Info::optional_uint32_user_sid, m_primitive_block.store_in_stringtable(""));
                         }
                         if (m_options.add_visible_flag) {
                             pbf_info.add_bool(OSMFormat::Info::optional_bool_visible, object.visible());
@@ -521,6 +544,7 @@ namespace osmium {
                     m_options.use_dense_nodes = file.is_not_false("pbf_dense_nodes");
                     m_options.use_compression = file.get("pbf_compression") != "none" && file.is_not_false("pbf_compression");
                     m_options.add_metadata = osmium::metadata_options{file.get("add_metadata")};
+                    m_options.default_metadata_values = file.is_true("default_metadata_values");
                     m_options.add_historical_information_flag = file.has_multiple_object_versions();
                     m_options.add_visible_flag = file.has_multiple_object_versions();
                     m_options.locations_on_ways = file.is_true("locations_on_ways");

--- a/include/osmium/io/detail/pbf_output_format.hpp
+++ b/include/osmium/io/detail/pbf_output_format.hpp
@@ -88,7 +88,7 @@ namespace osmium {
                 osmium::metadata_options add_metadata;
 
                 /// Write zeros to those metadata fields which should not be written?
-                bool default_metadata_values = false;
+                bool use_default_metadata_values = false;
 
                 /// Should nodes be encoded in DenseNodes?
                 bool use_dense_nodes = true;
@@ -288,27 +288,27 @@ namespace osmium {
 
                     if (m_options.add_metadata.version()) {
                         m_versions.push_back(static_cast_with_assert<int32_t>(node.version()));
-                    } else if (m_options.default_metadata_values) {
+                    } else if (m_options.use_default_metadata_values) {
                         m_versions.push_back(0);
                     }
                     if (m_options.add_metadata.timestamp()) {
                         m_timestamps.push_back(m_delta_timestamp.update(uint32_t(node.timestamp())));
-                    } else if (m_options.default_metadata_values) {
+                    } else if (m_options.use_default_metadata_values) {
                         m_timestamps.push_back(m_delta_timestamp.update(uint32_t(osmium::Timestamp())));
                     }
                     if (m_options.add_metadata.changeset()) {
                         m_changesets.push_back(m_delta_changeset.update(node.changeset()));
-                    } else if (m_options.default_metadata_values) {
+                    } else if (m_options.use_default_metadata_values) {
                         m_changesets.push_back(m_delta_changeset.update(0));
                     }
                     if (m_options.add_metadata.uid()) {
                         m_uids.push_back(m_delta_uid.update(node.uid()));
-                    } else if (m_options.default_metadata_values) {
+                    } else if (m_options.use_default_metadata_values) {
                         m_uids.push_back(m_delta_uid.update(0));
                     }
                     if (m_options.add_metadata.user()) {
                         m_user_sids.push_back(m_delta_user_sid.update(m_stringtable.add(node.user())));
-                    } else if (m_options.default_metadata_values) {
+                    } else if (m_options.use_default_metadata_values) {
                         // The first string in the string table is always an empty string.
                         m_user_sids.push_back(0);
                     }
@@ -332,21 +332,21 @@ namespace osmium {
 
                     pbf_dense_nodes.add_packed_sint64(OSMFormat::DenseNodes::packed_sint64_id, m_ids.cbegin(), m_ids.cend());
 
-                    if (m_options.add_metadata.any() || m_options.add_visible_flag || m_options.default_metadata_values) {
+                    if (m_options.add_metadata.any() || m_options.add_visible_flag || m_options.use_default_metadata_values) {
                         protozero::pbf_builder<OSMFormat::DenseInfo> pbf_dense_info{pbf_dense_nodes, OSMFormat::DenseNodes::optional_DenseInfo_denseinfo};
-                        if (m_options.add_metadata.version() || m_options.default_metadata_values) {
+                        if (m_options.add_metadata.version() || m_options.use_default_metadata_values) {
                             pbf_dense_info.add_packed_int32(OSMFormat::DenseInfo::packed_int32_version, m_versions.cbegin(), m_versions.cend());
                         }
-                        if (m_options.add_metadata.timestamp() || m_options.default_metadata_values) {
+                        if (m_options.add_metadata.timestamp() || m_options.use_default_metadata_values) {
                             pbf_dense_info.add_packed_sint64(OSMFormat::DenseInfo::packed_sint64_timestamp, m_timestamps.cbegin(), m_timestamps.cend());
                         }
-                        if (m_options.add_metadata.changeset() || m_options.default_metadata_values) {
+                        if (m_options.add_metadata.changeset() || m_options.use_default_metadata_values) {
                             pbf_dense_info.add_packed_sint64(OSMFormat::DenseInfo::packed_sint64_changeset, m_changesets.cbegin(), m_changesets.cend());
                         }
-                        if (m_options.add_metadata.uid() || m_options.default_metadata_values) {
+                        if (m_options.add_metadata.uid() || m_options.use_default_metadata_values) {
                             pbf_dense_info.add_packed_sint32(OSMFormat::DenseInfo::packed_sint32_uid, m_uids.cbegin(), m_uids.cend());
                         }
-                        if (m_options.add_metadata.user() || m_options.default_metadata_values) {
+                        if (m_options.add_metadata.user() || m_options.use_default_metadata_values) {
                             pbf_dense_info.add_packed_sint32(OSMFormat::DenseInfo::packed_sint32_user_sid, m_user_sids.cbegin(), m_user_sids.cend());
                         }
                         if (m_options.add_visible_flag) {
@@ -491,32 +491,32 @@ namespace osmium {
                         }
                     }
 
-                    if (m_options.add_metadata.any() || m_options.add_visible_flag || m_options.default_metadata_values) {
+                    if (m_options.add_metadata.any() || m_options.add_visible_flag || m_options.use_default_metadata_values) {
                         protozero::pbf_builder<OSMFormat::Info> pbf_info{pbf_object, T::enum_type::optional_Info_info};
 
                         if (m_options.add_metadata.version()) {
                             pbf_info.add_int32(OSMFormat::Info::optional_int32_version, static_cast_with_assert<int32_t>(object.version()));
-                        } else if (m_options.default_metadata_values) {
+                        } else if (m_options.use_default_metadata_values) {
                             pbf_info.add_int32(OSMFormat::Info::optional_int32_version, 0);
                         }
                         if (m_options.add_metadata.timestamp()) {
                             pbf_info.add_int64(OSMFormat::Info::optional_int64_timestamp, uint32_t(object.timestamp()));
-                        } else if (m_options.default_metadata_values) {
+                        } else if (m_options.use_default_metadata_values) {
                             pbf_info.add_int64(OSMFormat::Info::optional_int64_timestamp, uint32_t(osmium::Timestamp()));
                         }
                         if (m_options.add_metadata.changeset()) {
                             pbf_info.add_int64(OSMFormat::Info::optional_int64_changeset, object.changeset());
-                        } else if (m_options.default_metadata_values) {
+                        } else if (m_options.use_default_metadata_values) {
                             pbf_info.add_int64(OSMFormat::Info::optional_int64_changeset, 0);
                         }
                         if (m_options.add_metadata.uid()) {
                             pbf_info.add_int32(OSMFormat::Info::optional_int32_uid, static_cast_with_assert<int32_t>(object.uid()));
-                        } else if (m_options.default_metadata_values) {
+                        } else if (m_options.use_default_metadata_values) {
                             pbf_info.add_int32(OSMFormat::Info::optional_int32_uid, 0);
                         }
                         if (m_options.add_metadata.user()) {
                             pbf_info.add_uint32(OSMFormat::Info::optional_uint32_user_sid, m_primitive_block.store_in_stringtable(object.user()));
-                        } else if (m_options.default_metadata_values) {
+                        } else if (m_options.use_default_metadata_values) {
                             pbf_info.add_uint32(OSMFormat::Info::optional_uint32_user_sid, m_primitive_block.store_in_stringtable(""));
                         }
                         if (m_options.add_visible_flag) {
@@ -545,7 +545,7 @@ namespace osmium {
                     m_options.use_dense_nodes = file.is_not_false("pbf_dense_nodes");
                     m_options.use_compression = file.get("pbf_compression") != "none" && file.is_not_false("pbf_compression");
                     m_options.add_metadata = osmium::metadata_options{file.get("add_metadata")};
-                    m_options.default_metadata_values = file.is_true("default_metadata_values");
+                    m_options.use_default_metadata_values = file.is_true("use_default_metadata_values");
                     m_options.add_historical_information_flag = file.has_multiple_object_versions();
                     m_options.add_visible_flag = file.has_multiple_object_versions();
                     m_options.locations_on_ways = file.is_true("locations_on_ways");

--- a/include/osmium/io/detail/pbf_output_format.hpp
+++ b/include/osmium/io/detail/pbf_output_format.hpp
@@ -309,7 +309,8 @@ namespace osmium {
                     if (m_options.add_metadata.user()) {
                         m_user_sids.push_back(m_delta_user_sid.update(m_stringtable.add(node.user())));
                     } else if (m_options.default_metadata_values) {
-                        m_user_sids.push_back(m_delta_user_sid.update(m_stringtable.add("")));
+                        // The first string in the string table is always an empty string.
+                        m_user_sids.push_back(0);
                     }
                     if (m_options.add_visible_flag) {
                         m_visibles.push_back(node.visible());

--- a/include/osmium/io/detail/xml_output_format.hpp
+++ b/include/osmium/io/detail/xml_output_format.hpp
@@ -76,6 +76,9 @@ namespace osmium {
                 /// Which metadata of objects should be added?
                 osmium::metadata_options add_metadata;
 
+                /// Write zeros to those metadata fields which should not be written?
+                bool use_default_metadata_values = false;
+
                 /// Should the visible flag be added to all OSM objects?
                 bool add_visible_flag = false;
 
@@ -148,26 +151,38 @@ namespace osmium {
 
                     if (m_options.add_metadata.version() && object.version()) {
                         write_attribute("version", object.version());
+                    } else if (m_options.use_default_metadata_values) {
+                        write_attribute("version", 0);
                     }
 
                     if (m_options.add_metadata.timestamp() && object.timestamp()) {
                         *m_out += " timestamp=\"";
                         *m_out += object.timestamp().to_iso();
                         *m_out += "\"";
+                    } else if (m_options.use_default_metadata_values) {
+                        *m_out += " timestamp=\"";
+                        *m_out += osmium::Timestamp().to_iso(true);
+                        *m_out += "\"";
                     }
 
                     if (m_options.add_metadata.uid() && object.uid()) {
                         write_attribute("uid", object.uid());
+                    } else if (m_options.use_default_metadata_values) {
+                        write_attribute("uid", 0);
                     }
 
                     if (m_options.add_metadata.user() && object.user()[0] != '\0') {
                         *m_out += " user=\"";
                         append_xml_encoded_string(*m_out, object.user());
                         *m_out += "\"";
+                    } else if (m_options.use_default_metadata_values) {
+                        *m_out += " user=\"\"";
                     }
 
                     if (m_options.add_metadata.changeset() && object.changeset()) {
                         write_attribute("changeset", object.changeset());
+                    } else if (m_options.use_default_metadata_values) {
+                        write_attribute("changeset", 0);
                     }
 
                     if (m_options.add_visible_flag) {
@@ -429,6 +444,7 @@ namespace osmium {
                 XMLOutputFormat(osmium::thread::Pool& pool, const osmium::io::File& file, future_string_queue_type& output_queue) :
                     OutputFormat(pool, output_queue) {
                     m_options.add_metadata      = osmium::metadata_options{file.get("add_metadata")};
+                    m_options.use_default_metadata_values = file.is_true("use_default_metadata_values");
                     m_options.use_change_ops    = file.is_true("xml_change_format");
                     m_options.add_visible_flag  = (file.has_multiple_object_versions() || file.is_true("force_visible_flag")) && !m_options.use_change_ops;
                     m_options.locations_on_ways = file.is_true("locations_on_ways");

--- a/include/osmium/osm/timestamp.hpp
+++ b/include/osmium/osm/timestamp.hpp
@@ -238,11 +238,13 @@ namespace osmium {
          * Return the timestamp as string in ISO date/time
          * ("yyyy-mm-ddThh:mm:ssZ") format. If the timestamp is invalid, an
          * empty string will be returned.
+         *
+         * @param output_zero output the string even if it is 1970-01-01T00:00:00Z
          */
-        std::string to_iso() const {
+        std::string to_iso(const bool output_zero = false) const {
             std::string s;
 
-            if (m_timestamp != 0) {
+            if (m_timestamp != 0 || output_zero) {
                 struct tm tm;
                 time_t sse = seconds_since_epoch();
 #ifndef NDEBUG


### PR DESCRIPTION
Many applications including Libosmium < 2.14.0 and Osmosis require either all or no metadata fields in PBF files. They fail reading files which contain only version and timestamp fields. This pull request adds a new option `use_default_metadata_values=true` to write default values (`user="" uid=0 changeset=0`) to make these applications happy.