### PR TITLE
Test that RelationsManagerBase::get_member_object returns nullptr

### DIFF
--- a/test/t/relations/missing_members.osm
+++ b/test/t/relations/missing_members.osm
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="testdata" upload="false">
+    <node id="10" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1" lat="1.0" lon="1.0"/>
+    <node id="11" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1" lat="1.0" lon="1.1"/>
+    <node id="12" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1" lat="1.0" lon="1.2"/>
+    <node id="13" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1" lat="1.0" lon="1.3"/>
+    <node id="14" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1" lat="1.0" lon="1.4">
+      <tag k="amenity" v="bench" />
+    </node>
+    <way id="20" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
+        <tag k="public_transport" v="platform"/>
+        <nd ref="10"/>
+        <nd ref="11"/>
+    </way>
+    <way id="21" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
+        <tag k="public_transport" v="platform"/>
+        <nd ref="13"/>
+        <nd ref="12"/>
+    </way>
+    <relation id="31" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
+        <tag k="type" v="public_transport"/>
+        <tag k="public_transport" v="stop_area"/>
+        <member type="way" ref="20" role="platform"/>
+        <member type="way" ref="21" role="platform"/>
+        <member type="node" ref="14" role=""/>
+        <member type="relation" ref="30" role="building"/>
+        <member type="node" ref="15" role=""/>
+        <member type="relation" ref="32" role="building"/>
+        <member type="relation" ref="33" role="building"/>
+        <member type="way" ref="22" role="platform"/>
+    </relation>
+    <relation id="32" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
+        <tag k="type" v="multipolygon"/>
+        <tag k="public_transport" v="platform"/>
+        <member type="way" ref="23" role="outer"/>
+        <member type="way" ref="24" role="inner"/>
+    </relation>
+</osm>

--- a/test/t/relations/test_relations_manager.cpp
+++ b/test/t/relations/test_relations_manager.cpp
@@ -98,6 +98,16 @@ struct CallbackRM : public osmium::relations::RelationsManager<CallbackRM, true,
 
 };
 
+struct AnyRM : public osmium::relations::RelationsManager<AnyRM, true, true, true> {
+    bool new_relation(const osmium::Relation& /*relation*/) noexcept {
+        return true;
+    }
+
+    bool new_member(const osmium::Relation& /*relation*/, const osmium::RelationMember& /*member*/, std::size_t /*n*/) noexcept {
+        return true;
+    }
+};
+
 TEST_CASE("Use RelationsManager without any overloaded functions in derived class") {
     osmium::io::File file{with_data_dir("t/relations/data.osm")};
 
@@ -247,5 +257,66 @@ TEST_CASE("Handle duplicate members correctly") {
     REQUIRE(manager.count_new_members   == 5);
     REQUIRE(manager.count_complete_rels == 2);
     REQUIRE(manager.count_not_in_any    == 2); // 2 relations
+}
+
+TEST_CASE("Check handling of missing members") {
+    osmium::io::File file{with_data_dir("t/relations/missing_members.osm")};
+
+    AnyRM manager;
+
+    osmium::relations::read_relations(file, manager);
+
+    osmium::io::Reader reader{file};
+    osmium::apply(reader, manager.handler());
+    reader.close();
+
+
+    size_t nodes = 0;
+    size_t ways = 0;
+    size_t relations = 0;
+    size_t missing_nodes = 0;
+    size_t missing_ways = 0;
+    size_t missing_relations = 0;
+
+    manager.for_each_incomplete_relation([&](const osmium::relations::RelationHandle& handle){
+        if (handle->id() != 31) {
+            // count relation 31 only
+            return;
+        }
+        for (const auto& member : handle->members()) {
+            // RelationMember::ref() is supposed to returns 0 if we are interested in the member.
+            // RelationsManagerBase::get_member_object() is supposed to return a nullptr if the
+            // member is not available (missing in the input file).
+            const osmium::OSMObject* object = manager.get_member_object(member);
+            switch (member.type()) {
+            case osmium::item_type::node :
+                ++nodes;
+                if (member.ref() != 0 && !object) {
+                    ++missing_nodes;
+                }
+                break;
+            case osmium::item_type::way :
+                ++ways;
+                if (member.ref() != 0 && !object) {
+                    ++missing_ways;
+                }
+                break;
+            case osmium::item_type::relation :
+                ++relations;
+                if (member.ref() != 0 && !object) {
+                    ++missing_relations;
+                }
+                break;
+            default:
+                break;
+            }
+        }
+    });
+    REQUIRE(nodes == 2);
+    REQUIRE(ways == 3);
+    REQUIRE(relations == 3);
+    REQUIRE(missing_nodes == 1);
+    REQUIRE(missing_ways == 1);
+    REQUIRE(missing_relations == 2);
 }
 


### PR DESCRIPTION
This unit test checks the following statement from https://osmcode.org/libosmium/manual.html#working-with-relations:
> The pointers returned from the get_member_* functions will be nullptr if the member is not available.

@joto I decided to create `AnyRM` to explicitly state that I want to have all members. Or shall I intentionally rely on the current implemention in `osmium::relations::RelationsManager` and use `EmptyRM` instead.