### PR TITLE
Add test for SparseMmapArray, fix typo

### DIFF
--- a/test/t/index/test_id_to_location.cpp
+++ b/test/t/index/test_id_to_location.cpp
@@ -183,6 +183,20 @@ TEST_CASE("Map Id to location: SparseMemArray") {
     test_func_real<index_type>(index2);
 }
 
+#ifdef __linux__
+TEST_CASE("Map Id to location: SparseMmapArray") {
+    using index_type = osmium::index::map::SparseMmapArray<osmium::unsigned_object_id_type, osmium::Location>;
+
+    index_type index1;
+    test_func_all<index_type>(index1);
+
+    index_type index2;
+    test_func_real<index_type>(index2);
+}
+#else
+# pragma message("not running 'SparseMmapArray' test case on this machine")
+#endif
+
 TEST_CASE("Map Id to location: FlexMem sparse") {
     using index_type = osmium::index::map::FlexMem<osmium::unsigned_object_id_type, osmium::Location>;
 

--- a/test/t/index/test_id_to_location.cpp
+++ b/test/t/index/test_id_to_location.cpp
@@ -130,7 +130,7 @@ TEST_CASE("Map Id to location: DenseMmapArray") {
     test_func_real<index_type>(index2);
 }
 #else
-# pragma message("not running 'DenseMapMmap' test case on this machine")
+# pragma message("not running 'DenseMmapArray' test case on this machine")
 #endif
 
 TEST_CASE("Map Id to location: DenseFileArray") {


### PR DESCRIPTION
I was looking into the implementation of the FlexMem class today and looked how location indexes are tested.

SparseMmapArray is not tested in the same file where all other index types are tested (but it is covered by data tests). I added to be consistent.

In addition, I fixed an obvious typo in the same file.