### PR TITLE
Fix error: comparison of integer expression of different signedness

### DIFF
--- a/include/osmium/util/file.hpp
+++ b/include/osmium/util/file.hpp
@@ -181,7 +181,7 @@ namespace osmium {
             // https://msdn.microsoft.com/en-us/library/whx354w1.aspx
             if (::_chsize_s(fd, static_cast<__int64>(new_size)) != 0) {
 #else
-            assert(std::numeric_limits<off_t>::max() >= std::numeric_limits<size_t>::max() || new_size <= std::numeric_limits<off_t>::max());
+            assert(std::numeric_limits<off_t>::max() >= std::numeric_limits<size_t>::max() || new_size <= std::numeric_limits<std::size_t>::max());
             if (::ftruncate(fd, static_cast<off_t>(new_size)) != 0) {
 #endif
                 throw std::system_error{errno, std::system_category(), "Could not resize file"};

--- a/include/osmium/util/file.hpp
+++ b/include/osmium/util/file.hpp
@@ -181,7 +181,8 @@ namespace osmium {
             // https://msdn.microsoft.com/en-us/library/whx354w1.aspx
             if (::_chsize_s(fd, static_cast<__int64>(new_size)) != 0) {
 #else
-            assert(std::numeric_limits<off_t>::max() >= std::numeric_limits<size_t>::max() || new_size <= std::numeric_limits<std::size_t>::max());
+            assert(static_cast<std::size_t>(std::numeric_limits<off_t>::max()) >= std::numeric_limits<size_t>::max() ||
+                   new_size <= std::numeric_limits<std::size_t>::max());
             if (::ftruncate(fd, static_cast<off_t>(new_size)) != 0) {
 #endif
                 throw std::system_error{errno, std::system_category(), "Could not resize file"};


### PR DESCRIPTION
Fixes the following issue:

```bash
error: comparison of integer expressions of different signedness: ‘std::size_t’ {aka ‘long unsigned int’} and ‘long int’ [-Werror=sign-compare]
  184 |             assert(std::numeric_limits<off_t>::max() >= std::numeric_limits<size_t>::max() || new_size <= std::numeric_limits<off_t>::max());
      |                                                                                               ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```