### PR TITLE
AppVeyorCI: Fix MSYS2 build

### DIFF
--- a/build-msys2.bat
+++ b/build-msys2.bat
@@ -13,8 +13,8 @@ bash -lc "pacman -S --needed --noconfirm mingw-w64-x86_64-gcc mingw-w64-x86_64-g
 bash -lc "pacman -S --needed --noconfirm mingw-w64-x86_64-postgresql mingw-w64-x86_64-netcdf mingw-w64-x86_64-crypto++"
 call C:\msys64\mingw64\bin\gem.cmd install json
 
-REM Workaround for problem with gdal (see https://github.com/osmcode/libosmium/issues/262)
-copy /y C:\msys64\mingw64\bin\libjson-c-4.dll C:\msys64\mingw64\bin\libjson-c-3.dll
+REM Workaround for problem with spatialite (see https://github.com/osmcode/libosmium/issues/262)
+copy /y C:\msys64\mingw64\bin\libreadline8.dll C:\msys64\mingw64\bin\libreadline7.dll
 
 echo "Setting PROJ_LIB variable for correct PROJ.4 working"
 set PROJ_LIB=c:\msys64\mingw64\share\proj


### PR DESCRIPTION
The fix for gdal is available upstream and references the correct json-c dll.
The workaround (until reported/fixed upstream) provides a spatialite dependency: readline 7.