### PR TITLE
index speedup: after mmap, call madvise with MADV_RANDOM

### DIFF
--- a/include/osmium/util/memory_mapping.hpp
+++ b/include/osmium/util/memory_mapping.hpp
@@ -573,6 +573,7 @@ inline osmium::util::MemoryMapping::MemoryMapping(std::size_t size, mapping_mode
     m_fd(resize_fd(fd)),
     m_mapping_mode(mode),
     m_addr(::mmap(nullptr, m_size, get_protection(), get_flags(), m_fd, m_offset)) {
+    madvise(m_addr,m_size,MADV_RANDOM);
     assert(!(fd == -1 && mode == mapping_mode::readonly));
     if (!is_valid()) {
         throw std::system_error{errno, std::system_category(), "mmap failed"};
@@ -630,6 +631,7 @@ inline void osmium::util::MemoryMapping::resize(std::size_t new_size) {
         m_size = new_size;
         resize_fd(m_fd);
         m_addr = ::mmap(nullptr, new_size, get_protection(), get_flags(), m_fd, m_offset);
+        madvise(m_addr,new_size,MADV_RANDOM);
         if (!is_valid()) {
             throw std::system_error{errno, std::system_category(), "mmap (remap) failed"};
         }


### PR DESCRIPTION
This change results in a small but noticeable improvement of about 8% on my program which uses SparseFileArray for indexing node locations. Runs on a ~6GB .osm.pbf go from ~3450 seconds to 3200 seconds. 

http://man7.org/linux/man-pages/man2/madvise.2.html it should not change the behavior of the program but tweak the kernel paging slightly. Node locations seem random enough that readahead will always be detrimental, not sure where else this class is used though.

If others can reproduce the gains here and think it's useful, I can make sure it works on other platforms - only tested on Linux so far.