### PR TITLE
Fix location attr variable name typo

### DIFF
--- a/include/osmium/builder/attr.hpp
+++ b/include/osmium/builder/attr.hpp
@@ -227,8 +227,8 @@ namespace osmium {
             OSMIUM_ATTRIBUTE(node_handler, _location, osmium::Location)
                 constexpr explicit _location(const osmium::Location& value) noexcept :
                     type_wrapper(value) {}
-                explicit _location(double lat, double lon) :
-                    type_wrapper(osmium::Location{lat, lon}) {}
+                explicit _location(double lon, double lat) :
+                    type_wrapper(osmium::Location{lon, lat}) {}
             };
 
             OSMIUM_ATTRIBUTE(entity_handler, _user, const char*)


### PR DESCRIPTION
Looks like the names for these arguments are swapped, which could lead to confusion and subtle bugs. 