### PR TITLE
Explicitly export exception types.

### DIFF
--- a/include/gdalcpp.hpp
+++ b/include/gdalcpp.hpp
@@ -42,6 +42,8 @@ DEALINGS IN THE SOFTWARE.
 #include <ogr_api.h>
 #include <ogrsf_frmts.h>
 
+#include <osmium/util/compatibility.hpp>
+
 #include <cstdint>
 #include <algorithm>
 #include <memory>
@@ -63,7 +65,7 @@ namespace gdalcpp {
     /**
      * Exception thrown for all errors in this class.
      */
-    class gdal_error : public std::runtime_error {
+    class OSMIUM_EXPORT gdal_error : public std::runtime_error {
 
         std::string m_driver;
         std::string m_dataset;

--- a/include/osmium/geom/factory.hpp
+++ b/include/osmium/geom/factory.hpp
@@ -44,6 +44,7 @@ DEALINGS IN THE SOFTWARE.
 #include <osmium/osm/node_ref_list.hpp>
 #include <osmium/osm/types.hpp>
 #include <osmium/osm/way.hpp>
+#include <osmium/util/compatibility.hpp>
 
 #include <cstddef>
 #include <stdexcept>
@@ -56,7 +57,7 @@ namespace osmium {
      * Exception thrown when an invalid geometry is encountered. An example
      * would be a linestring with less than two points.
      */
-    class geometry_error : public std::runtime_error {
+    class OSMIUM_EXPORT geometry_error : public std::runtime_error {
 
         std::string m_message;
         osmium::object_id_type m_id;

--- a/include/osmium/geom/util.hpp
+++ b/include/osmium/geom/util.hpp
@@ -33,6 +33,8 @@ DEALINGS IN THE SOFTWARE.
 
 */
 
+#include <osmium/util/compatibility.hpp>
+
 #include <stdexcept>
 #include <string>
 
@@ -42,7 +44,7 @@ namespace osmium {
      * Exception thrown when a projection object can not be initialized or the
      * projection of some coordinates can not be calculated.
      */
-    struct projection_error : public std::runtime_error {
+    struct OSMIUM_EXPORT projection_error : public std::runtime_error {
 
         explicit projection_error(const std::string& what) :
             std::runtime_error(what) {

--- a/include/osmium/handler/check_order.hpp
+++ b/include/osmium/handler/check_order.hpp
@@ -39,6 +39,7 @@ DEALINGS IN THE SOFTWARE.
 #include <osmium/osm/relation.hpp>
 #include <osmium/osm/types.hpp>
 #include <osmium/osm/way.hpp>
+#include <osmium/util/compatibility.hpp>
 
 #include <limits>
 #include <stdexcept>
@@ -50,7 +51,7 @@ namespace osmium {
      * Exception thrown when a method in the CheckOrder class detects
      * that the input is out of order.
      */
-    struct out_of_order_error : public std::runtime_error {
+    struct OSMIUM_EXPORT out_of_order_error : public std::runtime_error {
 
         osmium::object_id_type object_id;
 

--- a/include/osmium/index/index.hpp
+++ b/include/osmium/index/index.hpp
@@ -33,6 +33,8 @@ DEALINGS IN THE SOFTWARE.
 
 */
 
+#include <osmium/util/compatibility.hpp>
+
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -45,7 +47,7 @@ namespace osmium {
      * Exception signaling that an element could not be
      * found in an index.
      */
-    struct not_found : public std::runtime_error {
+    struct OSMIUM_EXPORT not_found : public std::runtime_error {
 
         explicit not_found(const std::string& what) :
             std::runtime_error(what) {

--- a/include/osmium/index/map.hpp
+++ b/include/osmium/index/map.hpp
@@ -33,6 +33,7 @@ DEALINGS IN THE SOFTWARE.
 
 */
 
+#include <osmium/util/compatibility.hpp>
 #include <osmium/util/string.hpp>
 
 #include <algorithm>
@@ -47,7 +48,7 @@ DEALINGS IN THE SOFTWARE.
 
 namespace osmium {
 
-    struct map_factory_error : public std::runtime_error {
+    struct OSMIUM_EXPORT map_factory_error : public std::runtime_error {
 
         explicit map_factory_error(const char* message) :
             std::runtime_error(message) {

--- a/include/osmium/io/error.hpp
+++ b/include/osmium/io/error.hpp
@@ -33,6 +33,8 @@ DEALINGS IN THE SOFTWARE.
 
 */
 
+#include <osmium/util/compatibility.hpp>
+
 #include <stdexcept>
 #include <string>
 
@@ -41,7 +43,7 @@ namespace osmium {
     /**
      * Exception thrown when some kind of input/output operation failed.
      */
-    struct io_error : public std::runtime_error {
+    struct OSMIUM_EXPORT io_error : public std::runtime_error {
 
         explicit io_error(const std::string& what) :
             std::runtime_error(what) {

--- a/include/osmium/memory/buffer.hpp
+++ b/include/osmium/memory/buffer.hpp
@@ -55,7 +55,7 @@ namespace osmium {
      * to write data into a buffer and it doesn't fit. Buffers with internal
      * memory management will not throw this exception, but increase their size.
      */
-    struct buffer_is_full : public std::runtime_error {
+    struct OSMIUM_EXPORT buffer_is_full : public std::runtime_error {
 
         buffer_is_full() :
             std::runtime_error{"Osmium buffer is full"} {

--- a/include/osmium/osm/item_type.hpp
+++ b/include/osmium/osm/item_type.hpp
@@ -33,6 +33,8 @@ DEALINGS IN THE SOFTWARE.
 
 */
 
+#include <osmium/util/compatibility.hpp>
+
 #include <cassert>
 #include <cstdint> // IWYU pragma: keep
 #include <iosfwd>
@@ -192,7 +194,7 @@ namespace osmium {
      * probably means the buffer contains different kinds of objects than were
      * expected or that there is some kind of data corruption.
      */
-    struct unknown_type : public std::runtime_error {
+    struct OSMIUM_EXPORT unknown_type : public std::runtime_error {
 
         unknown_type() :
             std::runtime_error("unknown item type") {

--- a/include/osmium/util/compatibility.hpp
+++ b/include/osmium/util/compatibility.hpp
@@ -51,4 +51,10 @@ DEALINGS IN THE SOFTWARE.
 # define OSMIUM_DEPRECATED
 #endif
 
+#if defined(_MSC_VER)
+# define OSMIUM_EXPORT __declspec(dllexport)
+#else
+# define OSMIUM_EXPORT __attribute__ ((visibility("default")))
+#endif
+
 #endif // OSMIUM_UTIL_COMPATIBILITY_HPP


### PR DESCRIPTION
This should fix osmcode/pyosmium#165

Ref: pybind/pybind11#2999, [GCC Wiki](https://gcc.gnu.org/wiki/Visibility)