### PR TITLE
Read PBF files without an extra thread

### DIFF
--- a/include/osmium/io/compression.hpp
+++ b/include/osmium/io/compression.hpp
@@ -113,6 +113,10 @@ namespace osmium {
 
             virtual void close() = 0;
 
+            virtual bool is_real() const noexcept {
+                return true;
+            }
+
             std::size_t file_size() const noexcept {
                 return m_file_size;
             }
@@ -273,6 +277,37 @@ namespace osmium {
             }
 
         }; // class NoCompressor
+
+        /**
+         * The DummyDecompressor is used when reading PBF files. In that
+         * case the PBFParser class is responsible for reading from the
+         * file itself, and the DummyDecompressor does nothing.
+         */
+        class DummyDecompressor final : public Decompressor {
+        public:
+
+            DummyDecompressor() = default;
+
+            DummyDecompressor(const DummyDecompressor&) = delete;
+            DummyDecompressor& operator=(const DummyDecompressor&) = delete;
+
+            DummyDecompressor(DummyDecompressor&&) = delete;
+            DummyDecompressor& operator=(DummyDecompressor&&) = delete;
+
+            ~DummyDecompressor() noexcept override = default;
+
+            std::string read() override {
+                return {};
+            }
+
+            void close() override {
+            }
+
+            bool is_real() const noexcept override {
+                return false;
+            }
+
+        }; // class DummyDecompressor
 
         class NoDecompressor final : public Decompressor {
 

--- a/include/osmium/io/detail/input_format.hpp
+++ b/include/osmium/io/detail/input_format.hpp
@@ -58,6 +58,7 @@ namespace osmium {
 
             struct parser_arguments {
                 osmium::thread::Pool& pool;
+                int fd;
                 future_string_queue_type& input_queue;
                 future_buffer_queue_type& output_queue;
                 std::promise<osmium::io::Header>& header_promise;

--- a/test/data-tests/testdata-xml.cpp
+++ b/test/data-tests/testdata-xml.cpp
@@ -87,6 +87,7 @@ static header_buffer_type parse_xml(std::string input) {
 
     osmium::io::detail::parser_arguments args = {
         pool,
+        -1,
         input_queue,
         output_queue,
         header_promise,


### PR DESCRIPTION
Unlike XML or OPL files, PBF files are never packed into gzip or bzip2
as a whole. So we don't need the extra thread doing that unpacking.
This speeds up reading of PBF files.