### PR TITLE
Replace std::forward with std::move for clarity

### DIFF
--- a/include/osmium/builder/attr.hpp
+++ b/include/osmium/builder/attr.hpp
@@ -288,7 +288,7 @@ namespace osmium {
                 }
 
                 member_type_string(char type, osmium::object_id_type ref, std::string&& role) noexcept :
-                    member_type_string(osmium::char_to_item_type(type), ref, std::forward<std::string>(role)) {
+                    member_type_string(osmium::char_to_item_type(type), ref, std::move(role)) {
                 }
 
                 osmium::item_type type() const noexcept {

--- a/include/osmium/io/detail/input_format.hpp
+++ b/include/osmium/io/detail/input_format.hpp
@@ -267,7 +267,7 @@ namespace osmium {
                 }
 
                 bool register_parser(const osmium::io::file_format format, create_parser_type&& create_function) {
-                    callbacks(format) = std::forward<create_parser_type>(create_function);
+                    callbacks(format) = std::move(create_function);
                     return true;
                 }
 

--- a/include/osmium/io/detail/output_format.hpp
+++ b/include/osmium/io/detail/output_format.hpp
@@ -179,7 +179,7 @@ namespace osmium {
                 }
 
                 bool register_output_format(const osmium::io::file_format format, create_output_type&& create_function) {
-                    callbacks(format) = std::forward<create_output_type>(create_function);
+                    callbacks(format) = std::move(create_function);
                     return true;
                 }
 

--- a/include/osmium/thread/function_wrapper.hpp
+++ b/include/osmium/thread/function_wrapper.hpp
@@ -73,7 +73,7 @@ namespace osmium {
                 F m_functor;
 
                 explicit impl_type(F&& functor) :
-                    m_functor(std::forward<F>(functor)) {
+                    m_functor(std::move(functor)) {
                 }
 
                 bool call() override {

--- a/include/osmium/util/iterator.hpp
+++ b/include/osmium/util/iterator.hpp
@@ -44,7 +44,7 @@ namespace osmium {
         using iterator = It;
 
         explicit iterator_range(P&& p) noexcept :
-            P(std::forward<P>(p)) {
+            P(std::move(p)) {
         }
 
         It begin() const noexcept {


### PR DESCRIPTION
Hello,

Certain places had rvalues that were used with forward<...>(..)/
The code did the right thing, but the intent was not clear, at least to me.

Replaced with `std::move` where that was all that's needed/

Please, let me know if I missed something!

