### PR TITLE
Fix return type.

### DIFF
--- a/include/osmium/relations/members_database.hpp
+++ b/include/osmium/relations/members_database.hpp
@@ -159,7 +159,7 @@ namespace osmium {
                 return make_range(std::equal_range(m_elements.cbegin(), m_elements.cend(), element{id}, compare_member_id{}));
             }
 
-            static typename iterator_range<iterator>::iterator::difference_type count_not_removed(const iterator_range<iterator>& range) noexcept {
+            static typename std::iterator_traits<iterator>::difference_type count_not_removed(const iterator_range<iterator>& range) noexcept {
                 return std::count_if(range.begin(), range.end(), [](const element& elem) {
                     return !elem.is_removed();
                 });


### PR DESCRIPTION
Hello! I get an error due to include:
```cpp
#include <contrib/libs/libosmium/include/osmium/relations/relations_manager.hpp>
```
I use Ubuntu 20.04.1 LTS, clang version 12.0.1, libosmium version 2.17.0.
```bash
In file included from /contrib/libs/libosmium/include/osmium/relations/relations_manager.hpp:45:
/contrib/libs/libosmium/include/osmium/relations/members_database.hpp:162:55: error: 'osmium::iterator_range<osmium::relations::MembersDatabaseCommon::element *>::iterator' (aka 'osmium::relations::MembersDatabaseCommon::element *') is not a class, namespace, or enumeration
            static typename iterator_range<iterator>::iterator::difference_type count_not_removed(const iterator_range<iterator>& range) noexcept {
                                                      ^
1 error generated.
Failed
```

So I make PR to fix this problem.