### PR TITLE
catch.hpp: restore PPC support

### DIFF
--- a/test/catch/catch.hpp
+++ b/test/catch/catch.hpp
@@ -7950,6 +7950,9 @@ namespace Catch {
         #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
     #elif defined(__aarch64__)
         #define CATCH_TRAP()  __asm__(".inst 0xd4200000")
+    #elif defined(__POWERPC__)
+        #define CATCH_TRAP() __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" \
+        : : : "memory","r0","r3","r4" ) /* NOLINT */
     #endif
 
 #elif defined(CATCH_PLATFORM_IPHONE)

--- a/test/catch/catch.hpp
+++ b/test/catch/catch.hpp
@@ -7949,7 +7949,7 @@ namespace Catch {
     #if defined(__i386__) || defined(__x86_64__)
         #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
     #elif defined(__aarch64__)
-        #define CATCH_TRAP()  __asm__(".inst 0xd4200000")
+        #define CATCH_TRAP() __asm__(".inst 0xd4200000")
     #elif defined(__POWERPC__)
         #define CATCH_TRAP() __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" \
         : : : "memory","r0","r3","r4" ) /* NOLINT */
@@ -7959,13 +7959,13 @@ namespace Catch {
 
     // use inline assembler
     #if defined(__i386__) || defined(__x86_64__)
-        #define CATCH_TRAP()  __asm__("int $3")
+        #define CATCH_TRAP() __asm__("int $3")
     #elif defined(__aarch64__)
-        #define CATCH_TRAP()  __asm__(".inst 0xd4200000")
+        #define CATCH_TRAP() __asm__(".inst 0xd4200000")
     #elif defined(__arm__) && !defined(__thumb__)
-        #define CATCH_TRAP()  __asm__(".inst 0xe7f001f0")
+        #define CATCH_TRAP() __asm__(".inst 0xe7f001f0")
     #elif defined(__arm__) &&  defined(__thumb__)
-        #define CATCH_TRAP()  __asm__(".inst 0xde01")
+        #define CATCH_TRAP() __asm__(".inst 0xde01")
     #endif
 
 #elif defined(CATCH_PLATFORM_LINUX)


### PR DESCRIPTION
PPC define taken from earlier version of `libosmium`: https://github.com/osmcode/libosmium/blob/b293e96dbe2e3a9afe400768a990e107f8af3f02/test/catch/catch.hpp#L2128

Second commit is non-functional: removal of few unneeded double spaces.