### PR TITLE
Enable posix_fadvise usage on FreeBSD

### DIFF
--- a/include/osmium/io/detail/read_write.hpp
+++ b/include/osmium/io/detail/read_write.hpp
@@ -253,7 +253,7 @@ namespace osmium {
              * needed again soon. Keeps the buffer cache clear for other
              * things.
              */
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
             inline void remove_buffered_pages(int fd) noexcept {
                 if (fd > 0) {
                     ::posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
@@ -269,7 +269,7 @@ namespace osmium {
              * file that will not be needed again soon. Keeps the buffer cache
              * clear for other things.
              */
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
             inline void remove_buffered_pages(int fd, std::size_t size) noexcept {
                 constexpr const std::size_t block_size = 4096;
                 // Make sure to keep the last 10 blocks around, so were are

--- a/include/osmium/io/reader.hpp
+++ b/include/osmium/io/reader.hpp
@@ -248,7 +248,7 @@ namespace osmium {
 #endif
                 }
                 const int fd = osmium::io::detail::open_for_reading(filename);
-#if __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
                 if (fd >= 0) {
                     // Tell the kernel we are going to read this file sequentially
                     ::posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);


### PR DESCRIPTION
I see nothing which would prevent posix_fadvise from working on FreeBSD (or in fact all systems which have it, suggest to add cmake check) as well.
Not really tested (I do not use osmium), but build and tests pass.