### PR TITLE
Fix converting from .osc to .pbf

### DIFF
--- a/include/osmium/io/writer.hpp
+++ b/include/osmium/io/writer.hpp
@@ -277,6 +277,9 @@ namespace osmium {
 
                 m_header = options.header;
 
+                // Handle converting from .osc file into .pbf with HistoricalInformation(visible)
+                m_file.set_has_multiple_object_versions(m_header.has_multiple_object_versions());
+
                 m_output = osmium::io::detail::OutputFormatFactory::instance().create_output(*options.pool, m_file, m_output_queue);
 
                 std::unique_ptr<osmium::io::Compressor> compressor =


### PR DESCRIPTION
Problem was that .pbf never had `has_multiple_object_versions` set to true, hence it didn't emit `HistoricalInformation` and didn't write `Visible` values in protobuf

Please let me know if this belongs here(or elsewhere in this repo) or at https://github.com/osmcode/osmium-tool/blob/583db02ac9193dfb5217f93c823a4975405338ac/src/command_cat.cpp#L160

Once that is clarified I will add tests in correct repository.

P.S: Forgot to mention how to repro this... `osmium cat -o output.pbf 055.osc.gz`