### PR TITLE
replace dead site by official forum

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
-  - name: help.osm.org
-    url: https://help.openstreetmap.org/
+  - name: Official OpenStreetMap forum
+    url: https://community.openstreetmap.org/
     about: Ask questions and get support from the community.


### PR DESCRIPTION
https://help.openstreetmap.org/ has "NOTICE: help.openstreetmap.org is no longer in use from 1st March 2024. Please use the OpenStreetMap Community Forum"