### PR TITLE
Fix LTO linker warning

### DIFF
--- a/include/osmium/builder/osm_object_builder.hpp
+++ b/include/osmium/builder/osm_object_builder.hpp
@@ -470,7 +470,7 @@ namespace osmium {
              * @pre @code strlen(user) < 2^16 - 1 @endcode
              */
             TDerived& set_user(const char* user) {
-                const auto len = std::strlen(user);
+                const auto len = (user == nullptr) ? 0 : std::strlen(user);
                 assert(len < std::numeric_limits<string_size_type>::max());
                 return set_user(user, static_cast<string_size_type>(len));
             }


### PR DESCRIPTION
`warning: ‘__builtin_strlen’ reading 1 or more bytes from a region of size 0 [-Wstringop-overread]`