### PR TITLE
Include cassert in collection.hpp

### DIFF
--- a/include/osmium/memory/collection.hpp
+++ b/include/osmium/memory/collection.hpp
@@ -35,6 +35,7 @@ DEALINGS IN THE SOFTWARE.
 
 #include <osmium/memory/item.hpp>
 
+#include <cassert>
 #include <iosfwd>
 #include <iterator>
 #include <type_traits>


### PR DESCRIPTION
This fixes a compilation error where the `assert(.)` macro is not known:

```
#11 180.6 In file included from /src/third_party/libosmium/include/osmium/tags/filter.hpp:36,
#11 180.6                  from /src/include/extractor/restriction_parser.hpp:8,
#11 180.6                  from /src/src/extractor/restriction_parser.cpp:1:
#11 180.6 /src/third_party/libosmium/include/osmium/memory/collection.hpp: In instantiation of 'osmium::memory::CollectionFilterIterator<TFilter, TMember>& osmium::memory::CollectionFilterIterator<TFilter, TMember>::operator++() [with TFilter = osmium::tags::Filter<std::__cxx11::basic_string<char> >; TMember = const osmium::Tag]':
#11 180.6 /src/src/extractor/restriction_parser.cpp:101:34:   required from here
#11 180.6 /src/third_party/libosmium/include/osmium/memory/collection.hpp:148:23: error: 'assert' was not declared in this scope; did you mean 'mpl_::assert'?
...
```