### PR TITLE
Fix handling of global discussions files from planet.osm.org

### DIFF
--- a/include/osmium/builder/osm_object_builder.hpp
+++ b/include/osmium/builder/osm_object_builder.hpp
@@ -324,7 +324,7 @@ namespace osmium {
 
         class ChangesetDiscussionBuilder : public Builder {
 
-            osmium::ChangesetComment* m_comment = nullptr;
+            std::size_t m_comment_offset = SIZE_MAX;
 
             void add_user(osmium::ChangesetComment& comment, const char* user, const std::size_t length) {
                 if (length > osmium::max_osm_string_length) {
@@ -341,6 +341,16 @@ namespace osmium {
                 comment.set_text_size(static_cast<osmium::changeset_comment_size_type>(length) + 1);
                 add_size(append_with_zero(text, static_cast<osmium::memory::item_size_type>(length)));
                 add_padding(true);
+            }
+
+            // Get current comment pointer (recalculated each time to handle buffer reallocation)
+            osmium::ChangesetComment* get_comment_ptr() {
+                if (m_comment_offset == SIZE_MAX) {
+                    return nullptr;
+                }
+                return reinterpret_cast<osmium::ChangesetComment*>(
+                    buffer().data() + buffer().committed() + m_comment_offset
+                );
             }
 
         public:
@@ -362,32 +372,53 @@ namespace osmium {
             ChangesetDiscussionBuilder& operator=(ChangesetDiscussionBuilder&&) = delete;
 
             ~ChangesetDiscussionBuilder() {
-                assert(!m_comment && "You have to always call both add_comment() and then add_comment_text() in that order for each comment!");
+                assert(m_comment_offset == SIZE_MAX && "You have to always call both add_comment() and then add_comment_text() in that order for each comment!");
                 add_padding();
             }
 
             void add_comment(osmium::Timestamp date, osmium::user_id_type uid, const char* user) {
-                assert(!m_comment && "You have to always call both add_comment() and then add_comment_text() in that order for each comment!");
-                m_comment = reserve_space_for<osmium::ChangesetComment>();
-                new (m_comment) osmium::ChangesetComment{date, uid};
+                assert(m_comment_offset == SIZE_MAX && "You have to always call both add_comment() and then add_comment_text() in that order for each comment!");
+                
+                // Store offset instead of pointer to handle buffer reallocation
+                m_comment_offset = buffer().written() - buffer().committed();
+                
+                auto* comment = reserve_space_for<osmium::ChangesetComment>();
+                new (comment) osmium::ChangesetComment{date, uid};
                 add_size(sizeof(ChangesetComment));
-                add_user(*m_comment, user, std::strlen(user));
+                
+                auto* comment_ptr = get_comment_ptr();
+                add_user(*comment_ptr, user, std::strlen(user));
             }
 
             void add_comment_text(const char* text) {
-                assert(m_comment && "You have to always call both add_comment() and then add_comment_text() in that order for each comment!");
-                osmium::ChangesetComment& comment = *m_comment;
-                m_comment = nullptr;
+                assert(m_comment_offset != SIZE_MAX && "You have to always call both add_comment() and then add_comment_text() in that order for each comment!");
+                
+                // Get fresh pointer each time to handle buffer reallocation
+                auto* comment_ptr = get_comment_ptr();
+                osmium::ChangesetComment& comment = *comment_ptr;
+                
+                // Invalidate offset to ensure right adding order
+                m_comment_offset = SIZE_MAX;
+                
                 add_text(comment, text, std::strlen(text));
             }
 
             void add_comment_text(const std::string& text) {
-                assert(m_comment && "You have to always call both add_comment() and then add_comment_text() in that order for each comment!");
-                osmium::ChangesetComment& comment = *m_comment;
-                m_comment = nullptr;
+                assert(m_comment_offset != SIZE_MAX && "You have to always call both add_comment() and then add_comment_text() in that order for each comment!");
+                
+                // Get fresh pointer each time to handle buffer reallocation
+                auto* comment_ptr = get_comment_ptr();
+                osmium::ChangesetComment& comment = *comment_ptr;
+                
+                // Invalidate offset to ensure right adding order
+                m_comment_offset = SIZE_MAX;
+                
                 add_text(comment, text.c_str(), text.size());
             }
 
+            bool has_open_comment() const noexcept {
+                return m_comment_offset != SIZE_MAX;
+            }
         }; // class ChangesetDiscussionBuilder
 
 #define OSMIUM_FORWARD(setter) \


### PR DESCRIPTION
This PR fixes critical issues when processing global discussions files distributed by planet.osm.org, which contain changesets with comments. While libosmium can handle a large portion of the changesets, two issues would happen for some changesets.

### Problem

Global discussions files (changesets with comments) from planet.osm.org such as discussions-20250519.osm.bz2 were not being processed successfully due to two issues:

1. **Incomplete file reading**: These files use multi-stream bzip2 compression, but libosmium was stopping after the first stream, causing incomplete XML tag error at some point.
2. **Memory corruption during parsing**: Comments in changesets could cause invalid memory reading when the number of comments goes high.

The tested inpiut file is https://planet.osm.org/planet/2025/discussions-250519.osm.bz2. The first issue happened at about 21% of the processing. The second happened for changeset 62278154's 9th comment on my computer after resolving the first issue. Both `osmium::apply` and `osmium::io::make_input_iterator_range` present the same behavior.

### Solution

**1. Fix bzip2 multi-stream support**
- Modified bzip2 decompression in `include/osmium/io/bzip2_compression.hpp` to handle concatenated streams
- When one stream ends, automatically attempt to open the next stream in the file
- Only mark file as complete when no additional streams are available

**2. Improve memory-safety of ChangesetDiscussionBuilder**
- Replaced unsafe pointer storage with offset-based tracking in `include/osmium/builder/osm_object_builder.hpp`
- Added `get_comment_ptr()` method that safely recalculates pointers after buffer reallocations

### Impact

This fix enables reliable processing of planet.osm.org global discussions files by:
- Reading 100% of the global discussions data successfully (tested 20250519.osm.bz2).
- Maintaining backward compatibility with existing code

### Testing

Tested with all current unit tests to ensure the fix does not break anything.