### PR TITLE
Make NodeRef hashable

### DIFF
--- a/include/osmium/osm/node_ref.hpp
+++ b/include/osmium/osm/node_ref.hpp
@@ -39,6 +39,7 @@ DEALINGS IN THE SOFTWARE.
 
 #include <cstdint>
 #include <cstdlib>
+#include <functional>
 #include <iosfwd>
 
 namespace osmium {
@@ -233,5 +234,26 @@ namespace osmium {
     }; // struct location_less
 
 } // namespace osmium
+
+namespace std {
+
+// This pragma is a workaround for a bug in an old libc implementation
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmismatched-tags"
+#endif
+    template <>
+    struct hash<osmium::NodeRef> {
+        using argument_type = osmium::NodeRef;
+        using result_type = size_t;
+        size_t operator()(const osmium::NodeRef& nr) const noexcept {
+            return hash<osmium::object_id_type>{}(nr.ref());
+        }
+    };
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+} // namespace std
 
 #endif // OSMIUM_OSM_NODE_REF_HPP

--- a/test/t/osm/test_node_ref.cpp
+++ b/test/t/osm/test_node_ref.cpp
@@ -1,5 +1,8 @@
 #include "catch.hpp"
 
+#include <functional>
+#include <unordered_set>
+
 #include <osmium/builder/attr.hpp>
 #include <osmium/memory/buffer.hpp>
 #include <osmium/osm/node_ref.hpp>
@@ -16,7 +19,7 @@ TEST_CASE("Construct a NodeRef with an id") {
     REQUIRE(node_ref.ref() == 7);
 }
 
-TEST_CASE("Equality comparison fo NodeRefs") {
+TEST_CASE("Equality comparison of NodeRefs") {
     const osmium::NodeRef node_ref1{7, {1.2, 3.4}};
     const osmium::NodeRef node_ref2{7, {1.4, 3.1}};
     const osmium::NodeRef node_ref3{9, {1.2, 3.4}};
@@ -25,6 +28,31 @@ TEST_CASE("Equality comparison fo NodeRefs") {
     REQUIRE_FALSE(osmium::location_equal()(node_ref1, node_ref2));
     REQUIRE_FALSE(osmium::location_equal()(node_ref2, node_ref3));
     REQUIRE(      osmium::location_equal()(node_ref1, node_ref3));
+}
+
+TEST_CASE("Hash of NodeRefs") {
+    const osmium::NodeRef node_ref1{7, {1.2, 3.4}};
+    const osmium::NodeRef node_ref2{7, {1.4, 3.1}};
+    const osmium::NodeRef node_ref3{9, {1.2, 3.4}};
+
+    const std::hash<osmium::NodeRef> hasher;
+
+    SECTION("Equal NodeRefs have equal hashes") {
+        REQUIRE(hasher(node_ref1) == hasher(node_ref2));
+    }
+
+    SECTION("Different ref yields different hash") {
+        REQUIRE(hasher(node_ref1) != hasher(node_ref3));
+    }
+
+    SECTION("Hash is usable in unordered containers") {
+        std::unordered_set<osmium::NodeRef> set;
+        set.insert(node_ref1);
+        set.insert(node_ref2);
+        REQUIRE(set.size() == 1);
+        set.insert(node_ref3);
+        REQUIRE(set.size() == 2);
+    }
 }
 
 TEST_CASE("Set location on a NodeRef") {


### PR DESCRIPTION
Added `std::hash<osmium::NodeRef>` specialization (hashes `ref()` only, matching `operator==`) and unit tests for hash equality, inequality, and use in `std::unordered_set`.

### `include/osmium/osm/node_ref.hpp`
- Added `#include <functional>`
- Added `std::hash<osmium::NodeRef>` specialization that hashes only `ref()` — matching what `operator==` compares (ref-only). Follows the same pattern (clang pragma, argument_type/result_type) as the existing `std::hash<osmium::Location>` in location.hpp
- All comparison operators remain unchanged

### ` test/t/osm/test_node_ref.cpp`

- Added `#include <functional>` and `#include <unordered_set>`
- Equality test restored to original form
- Added "Hash of NodeRefs" test case with three sections:
  - Equal NodeRefs (same ref) → equal hashes
  - Different refs → different hashes
  - Usable in `std::unordered_set`
